### PR TITLE
gnoblet/issue106

### DIFF
--- a/R/add_shelter_issue_cat.R
+++ b/R/add_shelter_issue_cat.R
@@ -43,7 +43,7 @@ add_shelter_issue_cat <- function(
     df,
     new_colname = "snfi_shelter_issue_n",
     vars = shelter_issue_d_issues,
-    na_rm = FALSE,
+    na_rm = TRUE,
     imputation = "none"
   )
 

--- a/tests/testthat/test-add_shelter_issue_cat.R
+++ b/tests/testthat/test-add_shelter_issue_cat.R
@@ -60,7 +60,7 @@ test_that("add_shelter_issue_cat handles undefined values", {
     'snfi_shelter_issue/other' = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0),
     'snfi_shelter_issue/none' = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1),
     'snfi_shelter_issue/lack_privacy' = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-    'snfi_shelter_issue/pnta' = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    'snfi_shelter_issue/pnta' = c(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
 
 
   )


### PR DESCRIPTION
If data are cleaned, binary columns should not contain NAs, so ok to have `sum_vars()` with `na_rm = T` for now!