### PR TITLE
Update to issue550

### DIFF
--- a/R/add_comp_health.R
+++ b/R/add_comp_health.R
@@ -61,7 +61,7 @@ add_comp_health <- function(
         !!rlang::sym(ind_healthcare_needed_yes_unmet_n) > 0 ~ 3,
         !!rlang::sym(ind_healthcare_needed_yes_met_wgq_dis_n) > 0 ~ 3,
         !!rlang::sym(ind_healthcare_needed_yes_met_n) > 0 ~ 2,
-        !!rlang::sym(ind_healthcare_needed_no_wgq_dis_n) > 0 ~ 2,
+        !!rlang::sym(ind_healthcare_needed_no_wgq_dis_n) > 0 ~ 3,
         !!rlang::sym(ind_healthcare_needed_no_n) > 0 ~ 1,
         .default = NA_real_
       )


### PR DESCRIPTION
Updated severity calculation for ind_healthcare_needed_no_wgq_dis_n (the number of individuals who did not need to access healthcare and have a disability)> 0 from 3 to 2. In the analytical framework, households with at least one person with a disability must have the value 3. 

<img width="514" alt="image" src="https://github.com/user-attachments/assets/68084e2c-fcce-461b-af59-c36b2d037363">
