### PR TITLE
Issue 549 Allow custom starting age for education analysis based on country specific requirements

### DIFF
--- a/R/add_loop_edu_ind_age_corrected.R
+++ b/R/add_loop_edu_ind_age_corrected.R
@@ -1,22 +1,26 @@
-#' @title Add Correct Schooling Age to Individual Data
-#'
-#' @description This function adds a corrected age for schooling purposes to individual-level data and creates a dummy variable for school-age children. It also provides an option to aggregate this information to household-level data.
+#' Add a correct schooling age to the loop
 #'
 #' @param loop A data frame of individual-level data.
-#' @param main A data frame of household-level data.
-#' @param id_col_loop Survey unique identifier column name in loop.
-#' @param id_col_main Survey unique identifier column name in main.
-#' @param survey_start_date Survey start date column name in main.
-#' @param school_year_start_month The month when the school year has started.
-#' @param ind_age The individual age column.
-#' @param month If not NULL, an integer between 1 and 12 which will be used as the month of data collection for all households.
-#'
-#' @return A data frame with additional columns:
-#' \item{edu_ind_age_corrected}{The corrected individual age for schooling purposes}
-#' \item{edu_ind_schooling_age_d}{A dummy variable indicating if the individual is of school age (1) or not (0)}
+#' @param main A data frame of individual-level data.
+#' @param id_col_loop  Survey unique identifier column name in loop.
+#' @param id_col_main  Survey unique identifier column name in main.
+#' @param survey_start_date  Survey start date column name in main.
+#' @param school_year_start_month  The month when the school year has started.
+#' @param ind_age  The individual age column.
+#' @param month  If not NULL, an integer between 1 and 12 which will be used as the month of data collection for all households.
+#' @param schooling_start_age The age at which we assign the value 1 to edu_ind_schooling_age_d. Default is 5.
+#' @return 2 new columns: "edu_ind_age_corrected" with the corrected individual age, and a dummy variable edu_ind_schooling_age_d
 #'
 #' @export
-add_loop_edu_ind_age_corrected <- function(loop, main, id_col_loop = "uuid", id_col_main = "uuid", survey_start_date = "start", school_year_start_month = 9, ind_age = "ind_age", month = NULL) {
+add_loop_edu_ind_age_corrected <- function(loop,
+                                           main,
+                                           id_col_loop = "uuid",
+                                           id_col_main = "uuid",
+                                           survey_start_date = "start",
+                                           school_year_start_month = 9,
+                                           ind_age = "ind_age",
+                                           month = NULL,
+                                           schooling_start_age = 5) {
 
   #------ Initial checks
 
@@ -67,14 +71,14 @@ add_loop_edu_ind_age_corrected <- function(loop, main, id_col_loop = "uuid", id_
   loop <- dplyr::mutate(loop, edu_ind_age_corrected = dplyr::case_when(
     !is.na(!!rlang::sym("month")) & !is.na(!!sym(ind_age)) & (!!rlang::sym("month") - school_year_start_month_adj) > 6 ~ !!rlang::sym(ind_age) - 1,
     .default = !!rlang::sym(ind_age)
-    )
+  )
   )
 
-  #Final classification --- NAing with below 5 or under 17
+  #Final classification --- NAing with below schooling_start_age or under 17
   loop <- dplyr::mutate(
     loop,
     edu_ind_age_corrected = dplyr::case_when(
-      !!rlang::sym("edu_ind_age_corrected") < 5 | !!rlang::sym("edu_ind_age_corrected") > 17 ~ NA_real_,
+      !!rlang::sym("edu_ind_age_corrected") < schooling_start_age | !!rlang::sym("edu_ind_age_corrected") > 17 ~ NA_real_,
       .default = !!rlang::sym("edu_ind_age_corrected")
     )
   )
@@ -84,7 +88,7 @@ add_loop_edu_ind_age_corrected <- function(loop, main, id_col_loop = "uuid", id_
     loop,
     edu_ind_schooling_age_d = dplyr::case_when(
       is.na(!!rlang::sym("edu_ind_age_corrected")) ~ 0,
-      !!rlang::sym("edu_ind_age_corrected") < 5 | !!rlang::sym("edu_ind_age_corrected") > 17 ~ 0,
+      !!rlang::sym("edu_ind_age_corrected") < schooling_start_age | !!rlang::sym("edu_ind_age_corrected") > 17 ~ 0,
       .default = 1
     )
   )


### PR DESCRIPTION
Per Ed team request, modified add_loop_edu_ind_age_corrected.R  to allow for custom starting age. Kept default starting age = 5 per Martina Vit (Ed team). Test passed without changes. 