### PR TITLE
small fix to remove warnings all_of() in original code

### DIFF
--- a/R/add_loop_wgq_ss.R
+++ b/R/add_loop_wgq_ss.R
@@ -91,7 +91,7 @@ add_loop_wgq_ss <- function(
   loop <- dplyr::mutate(
     loop,
     dplyr::across(
-      wgq_vars,
+      dplyr::all_of(wgq_vars),
       \(x) dplyr::case_when(
         ind_age_above_5 == 0 ~ NA_real_,
         ind_age_above_5 == 1 & x %in% undefined ~ 0,
@@ -108,7 +108,7 @@ add_loop_wgq_ss <- function(
   loop <- dplyr::mutate(
     loop,
     dplyr::across(
-      wgq_vars,
+      dplyr::all_of(wgq_vars),
       \(x) dplyr::case_when(
         ind_age_above_5 == 0 ~ NA_real_,
         ind_age_above_5 == 1 & x %in% undefined ~ 0,
@@ -124,7 +124,7 @@ add_loop_wgq_ss <- function(
   loop <- dplyr::mutate(
     loop,
     dplyr::across(
-      wgq_vars,
+      dplyr::all_of(wgq_vars),
       \(x) dplyr::case_when(
         ind_age_above_5 == 0 ~ NA_real_,
         ind_age_above_5 == 1 & x %in% undefined ~ 0,


### PR DESCRIPTION
add dplyr::all_of() in some of the code that was missing to remove the warning ! Using an external vector in selections was deprecated in tidyselect 1.1.0.