### PR TITLE
:rotating_light: (tests and coverage) Correctly initialize the usage  of {testthat}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,9 @@ Remotes:
 Suggests: 
     knitr,
     rmarkdown,
-    roxygen2
+    roxygen2,
+    testthat (>= 3.0.0)
 LazyData: true
 Config/Needs/website: rmarkdown
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(humind)
+
+test_check("humind")


### PR DESCRIPTION
Initialize {testthat} with {usethis} to comply with recommended structure, and enable test coverage reports with {covr}

Closes #607 