### PR TITLE
Issue618 update unit tests for add occupancy cat

### DIFF
--- a/man/add_shelter_issue_cat.Rd
+++ b/man/add_shelter_issue_cat.Rd
@@ -35,7 +35,7 @@ add_shelter_issue_cat(
 A data frame with additional columns:
 \itemize{
 \item snfi_shelter_issue_n: Count of shelter issues.
-\item snfi_shelter_issue_cat: Categorized shelter issues: "none", "undefined", "other", "1_to_3", "4_to_6", or "7_to_8".
+\item snfi_shelter_issue_cat: Categorized shelter issues: "none", "undefined", "other", "1_to_3", "4_to_7", or "8_to_11".
 }
 }
 \description{


### PR DESCRIPTION
 Issue related : [2025 Update| Update unit tests for add_occupancy_cat.R #618](https://github.com/impact-initiatives-hppu/humind/issues/618)


This pull request includes updates to the test coverage for the `add_occupancy_cat` function, as well as adjustments to the documentation for shelter issue categorization. 

### Test Enhancements:
* Refactored and expanded unit tests in `tests/testthat/test-add_occupancy_cat.R`:
  - Added comprehensive tests for `hlp_occupancy_cat`, `hlp_eviction_cat`, and `hlp_tenure_security` assignments across all combinations of input data.
  - Introduced error handling tests for missing required columns (`hlp_occupancy` or `hlp_risk_eviction`) and out-of-range values.
  - Added edge case tests for scenarios where all values are `NA`.

### Documentation update:
* Updated documentation for `R/add_shelter_issue_cat.R` function

--- 
Automatic issue closure 
CLOSES: #618 