### PR TITLE
Pre release Clean up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
 URL: https://github.com/impact-initiatives-hppu/humind
 BugReports: https://github.com/impact-initiatives-hppu/humind/issues
 Remotes: 
-    gnoblet/impactR.utils,
+    impact-initiatives/impactR.utils,
     impact-initiatives/impactR4PHU
 Suggests: 
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,11 +31,9 @@ Remotes:
     impact-initiatives/impactR.utils,
     impact-initiatives/impactR4PHU
 Suggests: 
-    knitr,
     rmarkdown,
     roxygen2,
     testthat (>= 3.0.0)
 LazyData: true
 Config/Needs/website: rmarkdown
-VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -27,18 +27,19 @@
 #' @param shelter_issue_cat_none Level for no shelter issues.
 #' @param shelter_issue_cat_undefined Level for undefined shelter issues.
 #' @param shelter_issue_cat_other Level for other shelter issues.
-#' @param tenure_security Column name for security of tenure.
-#' @param tenure_security_high_risk Level for high risk with security of tenure.
-#' @param tenure_security_medium_risk Level for medium risk with security of tenure.
-#' @param tenure_security_low_risk Level for low risk with security of tenure.
-#' @param tenure_security_undefined Level for undefined with security of tenure.
+#' @param tenure_security_cat Column name for security of tenure.
+#' @param tenure_security_cat_high_risk Level for high risk with security of tenure.
+#' @param tenure_security_cat_medium_risk Level for medium risk with security of tenure.
+#' @param tenure_security_cat_low_risk Level for low risk with security of tenure.
+#' @param tenure_security_cat_undefined Level for undefined with security of tenure.
 #' @param fds_cannot_cat Column name for fds cannot.
 #' @param fds_cannot_cat_4 Level for 4 tasks that cannot be done.
 #' @param fds_cannot_cat_2_to_3 Level for 2 to 3 tasks that cannot be done.
 #' @param fds_cannot_cat_1 Level for 1 task that cannot be done.
 #' @param fds_cannot_cat_none Level for no tasks that cannot be done.
 #' @param fds_cannot_cat_undefined Level for undefined fds cannot.
-#' @param shelter_damage_cat Column for shelter damage.
+#' @param shelter_damage Column for shelter damage.
+#' @param shelter_damage_cat Column for shelter damage category.
 #' @param shelter_damage_cat_none Level name for no shelter damage.
 #' @param shelter_damage_cat_damaged Level name for minor damages.
 #' @param shelter_damage_cat_part Level name for roof with risk of collapse.
@@ -46,10 +47,10 @@
 #' @param shelter_damage_cat_undefined Level name for undefined or unknown status for shelter damage.
 #'
 #' @return A data frame with added columns:
-#' * comp_snfi_score_shelter_type_cat: Score based on shelter type
-#' * comp_snfi_score_shelter_issue_cat: Score based on shelter issues
-#' * comp_snfi_score_tenure_security_cat: Score based on security of tenure status
-#' * comp_snfi_score_fds_cannot_cat: Score based on FDS
+#' * comp_snfi_score_shelter_type_cat Score based on shelter type
+#' * comp_snfi_score_shelter_issue_cat Score based on shelter issues
+#' * comp_snfi_score_tenure_security_cat Score based on security of tenure status
+#' * comp_snfi_score_fds_cannot_cat Score based on FDS
 #' * comp_snfi_score: Overall SNFI composite score
 #' * comp_snfi_in_need: Indicator for being in need
 #' * comp_snfi_in_acute_need: Indicator for being in acute need

--- a/R/add_shelter_issue_cat.R
+++ b/R/add_shelter_issue_cat.R
@@ -92,8 +92,16 @@ add_shelter_issue_cat <- function(
   df <- dplyr::mutate(
     df,
     snfi_shelter_issue_n = dplyr::case_when(
-      dplyr::if_any(shelter_issue_d_undefined, \(x) x == 1) ~ -999,
-      dplyr::if_any(shelter_issue_d_other, \(x) x == 1) ~ -998,
+      dplyr::if_any(
+        dplyr::all_of(shelter_issue_d_undefined),
+        \(x) x == 1
+      ) ~
+        -999,
+      dplyr::if_any(
+        dplyr::all_of(shelter_issue_d_other),
+        \(x) x == 1
+      ) ~
+        -998,
       !!rlang::sym(shelter_issue_d_none) == 1 ~ 0,
       .default = !!rlang::sym("snfi_shelter_issue_n")
     )

--- a/R/num_cat.R
+++ b/R/num_cat.R
@@ -1,7 +1,7 @@
 #' @title Add Categories for a Numeric Variable
-#' 
+#'
 #' @description This function categorizes a numeric column in a dataframe based on specified breaks and labels. It can handle undefined values and provides options for customizing the categorization process.
-#' 
+#'
 #' @param df A dataframe containing the numeric column to be categorized.
 #' @param num_col The column name to recategorize.
 #' @param breaks A vector of cut points for categorization.
@@ -11,14 +11,23 @@
 #' @param new_colname The name of the new column. If NULL, it's automatically generated.
 #' @param plus_last Logical, whether to add a "+" to the last category.
 #' @param above_last Logical, whether to add a category for values above the last break.
-#' 
+#'
 #' @return A dataframe with an additional column:
-#' 
+#'
 #' * new_colname: A new column containing the categorized values of the original numeric column.
 #'
 #' @export
-num_cat <- function(df, num_col, breaks, labels = NULL, int_undefined = c(-999, 999),
-                    char_undefined = "Unknown", new_colname = NULL, plus_last = FALSE, above_last = FALSE) {
+num_cat <- function(
+  df,
+  num_col,
+  breaks,
+  labels = NULL,
+  int_undefined = c(-999, 999),
+  char_undefined = "Unknown",
+  new_colname = NULL,
+  plus_last = FALSE,
+  above_last = FALSE
+) {
   #------ Checks
 
   # Check if num_col is in df
@@ -28,16 +37,24 @@ num_cat <- function(df, num_col, breaks, labels = NULL, int_undefined = c(-999, 
   are_cols_numeric(df, num_col)
 
   # Check if int_dontknow is numeric
-  if (!all(sapply(int_undefined, is.numeric))) rlang::abort("int_dontknow must only contain numeric values")
+  if (!all(sapply(int_undefined, is.numeric))) {
+    rlang::abort("int_dontknow must only contain numeric values")
+  }
 
   # Check if char_dontknow is of length 1
-  if (length(char_undefined) != 1) rlang::abort("char_dontknow must be of length 1")
+  if (length(char_undefined) != 1) {
+    rlang::abort("char_dontknow must be of length 1")
+  }
 
   # Check if char_dontknow is character
-  if (!is.character(char_undefined)) rlang::abort("char_dontknow must be a character")
+  if (!is.character(char_undefined)) {
+    rlang::abort("char_dontknow must be a character")
+  }
 
   # Check if breaks have at least two values
-  if (length(breaks) < 2) rlang::abort("breaks must have at least two values")
+  if (length(breaks) < 2) {
+    rlang::abort("breaks must have at least two values")
+  }
 
   # Check that above_last is logical and not NA
   if (!is.logical(above_last) || is.na(above_last)) {
@@ -46,17 +63,19 @@ num_cat <- function(df, num_col, breaks, labels = NULL, int_undefined = c(-999, 
 
   # Check if labels is of length of breaks if above_last is TRUE
   if (!is.null(labels) && length(labels) != length(breaks) && above_last) {
-    rlang::warn("labels must be of length of breaks. Reverting to labels = NULL")
+    rlang::warn(
+      "labels must be of length of breaks. Reverting to labels = NULL"
+    )
     labels <- NULL
   }
 
   # Check if labels is of length of breaks - 1 if above_last is FALSE
   if (!is.null(labels) && length(labels) != length(breaks) - 1 && !above_last) {
-    rlang::warn("labels must be of length of breaks - 1. Reverting to labels = NULL")
+    rlang::warn(
+      "labels must be of length of breaks - 1. Reverting to labels = NULL"
+    )
     labels <- NULL
   }
-
-
 
   # Check that plus_last is logical and not NA
   if (!is.logical(plus_last) || is.na(plus_last)) {
@@ -64,27 +83,34 @@ num_cat <- function(df, num_col, breaks, labels = NULL, int_undefined = c(-999, 
   }
 
   # If new_colname is not provided, create one
-  if (is.null(new_colname)) new_colname <- paste0(num_col, "_cat")
+  if (is.null(new_colname)) {
+    new_colname <- paste0(num_col, "_cat")
+  }
 
   #----- Create labels if NULL
 
   vals <- df[[num_col]]
   vals <- vals[!(vals %in% int_undefined)]
-  max_val <- max(vals, na.rm = TRUE)
+  max_val <- max(vals, na.rm = TRUE, default = -Inf)
 
   # Total number of breaks
-  if (above_last) breaks <- c(breaks, Inf)
+  if (above_last) {
+    breaks <- c(breaks, Inf)
+  }
 
   # If labels are not provided, generate them
   if (is.null(labels)) {
-
     labels <- sapply(1:(length(breaks) - 1), function(i) {
       lower <- breaks[i]
       upper <- breaks[i + 1]
       if (i == length(breaks) - 1 && plus_last) {
         return(paste0(lower, "+"))
       } else if (i == length(breaks) - 1 && !plus_last) {
-        if (lower == max_val) return(paste0(lower, "+")) else return(paste0(lower, "-", max_val))
+        if (lower == max_val) {
+          return(paste0(lower, "+"))
+        } else {
+          return(paste0(lower, "-", max_val))
+        }
       } else {
         return(paste0(lower, "-", upper - 1))
       }
@@ -92,17 +118,21 @@ num_cat <- function(df, num_col, breaks, labels = NULL, int_undefined = c(-999, 
   }
 
   # Create categories
-  df <- dplyr::mutate(df, "{new_colname}" := dplyr::case_when(
-    # Replace value in int_dontkow by char_dontknow
-    !!rlang::sym(num_col) %in% int_undefined ~ char_undefined,
-    # Replace values below min(breaks) by NA
-    !!rlang::sym(num_col) < min(breaks) ~ NA_character_,
-    # Create categories using function cut and adjusted breaks
-    .default = cut(!!rlang::sym(num_col),
-                   breaks = breaks,
-                   labels = labels,
-                   include.lowest = TRUE,
-                   right = FALSE)
+  df <- dplyr::mutate(
+    df,
+    "{new_colname}" := dplyr::case_when(
+      # Replace value in int_dontkow by char_dontknow
+      !!rlang::sym(num_col) %in% int_undefined ~ char_undefined,
+      # Replace values below min(breaks) by NA
+      !!rlang::sym(num_col) < min(breaks) ~ NA_character_,
+      # Create categories using function cut and adjusted breaks
+      .default = cut(
+        !!rlang::sym(num_col),
+        breaks = breaks,
+        labels = labels,
+        include.lowest = TRUE,
+        right = FALSE
+      )
     )
   )
 

--- a/man/add_comp_snfi.Rd
+++ b/man/add_comp_snfi.Rd
@@ -65,6 +65,16 @@ add_comp_snfi(
 
 \item{shelter_issue_cat_other}{Level for other shelter issues.}
 
+\item{tenure_security_cat}{Column name for security of tenure.}
+
+\item{tenure_security_cat_high_risk}{Level for high risk with security of tenure.}
+
+\item{tenure_security_cat_medium_risk}{Level for medium risk with security of tenure.}
+
+\item{tenure_security_cat_low_risk}{Level for low risk with security of tenure.}
+
+\item{tenure_security_cat_undefined}{Level for undefined with security of tenure.}
+
 \item{fds_cannot_cat}{Column name for fds cannot.}
 
 \item{fds_cannot_cat_4}{Level for 4 tasks that cannot be done.}
@@ -77,7 +87,9 @@ add_comp_snfi(
 
 \item{fds_cannot_cat_undefined}{Level for undefined fds cannot.}
 
-\item{shelter_damage_cat}{Column for shelter damage.}
+\item{shelter_damage}{Column for shelter damage.}
+
+\item{shelter_damage_cat}{Column for shelter damage category.}
 
 \item{shelter_damage_cat_none}{Level name for no shelter damage.}
 
@@ -88,24 +100,14 @@ add_comp_snfi(
 \item{shelter_damage_cat_total}{Level name for total collapse or destruction.}
 
 \item{shelter_damage_cat_undefined}{Level name for undefined or unknown status for shelter damage.}
-
-\item{tenure_security}{Column name for security of tenure.}
-
-\item{tenure_security_high_risk}{Level for high risk with security of tenure.}
-
-\item{tenure_security_medium_risk}{Level for medium risk with security of tenure.}
-
-\item{tenure_security_low_risk}{Level for low risk with security of tenure.}
-
-\item{tenure_security_undefined}{Level for undefined with security of tenure.}
 }
 \value{
 A data frame with added columns:
 \itemize{
-\item comp_snfi_score_shelter_type_cat: Score based on shelter type
-\item comp_snfi_score_shelter_issue_cat: Score based on shelter issues
-\item comp_snfi_score_tenure_security_cat: Score based on security of tenure status
-\item comp_snfi_score_fds_cannot_cat: Score based on FDS
+\item comp_snfi_score_shelter_type_cat Score based on shelter type
+\item comp_snfi_score_shelter_issue_cat Score based on shelter issues
+\item comp_snfi_score_tenure_security_cat Score based on security of tenure status
+\item comp_snfi_score_fds_cannot_cat Score based on FDS
 \item comp_snfi_score: Overall SNFI composite score
 \item comp_snfi_in_need: Indicator for being in need
 \item comp_snfi_in_acute_need: Indicator for being in acute need

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,5 +1,6 @@
 library(stringr)
 library(dplyr)
+library(tidyr)
 
 generate_survey_choice_combinations <- function(
   question_name,

--- a/tests/testthat/test-add_access_to_phone_best.R
+++ b/tests/testthat/test-add_access_to_phone_best.R
@@ -1,10 +1,13 @@
-library(testthat)
-library(dplyr)
-
 # Sample data for testing
-df <- tibble::tibble(
+df <- dplyr::tibble(
   id = 1:5,
-  etc_access_to_phone = c("smartphone", "feature_phone", "basic_phone", "none", "dnk"),
+  etc_access_to_phone = c(
+    "smartphone",
+    "feature_phone",
+    "basic_phone",
+    "none",
+    "dnk"
+  ),
   `etc_access_to_phone/smartphone` = c(1, 0, 0, 0, 0),
   `etc_access_to_phone/feature_phone` = c(0, 1, 0, 0, 0),
   `etc_access_to_phone/basic_phone` = c(0, 0, 1, 0, 0),
@@ -12,20 +15,38 @@ df <- tibble::tibble(
   `etc_access_to_phone/dnk` = c(0, 0, 0, 0, 1),
   `etc_access_to_phone/pnta` = c(0, 0, 0, 0, 0),
   `etc_access_to_phone/other` = c(0, 0, 0, 0, 0),
-  etc_coverage_network_type = c("voice_sms_internet", "only_sms","voice_sms", "no_coverage", "dnk")
+  etc_coverage_network_type = c(
+    "voice_sms_internet",
+    "only_sms",
+    "voice_sms",
+    "no_coverage",
+    "dnk"
+  )
 )
 
 test_that("add_access_to_phone_best correctly categorizes phone access", {
   result <- add_access_to_phone_best(df)
 
-  expect_equal(result$etc_access_to_phone_best, c("smartphone", "feature_phone", "basic_phone", "none", "undefined"))
+  expect_equal(
+    result$etc_access_to_phone_best,
+    c("smartphone", "feature_phone", "basic_phone", "none", "undefined")
+  )
 })
 
 test_that("add_access_to_phone_coverage correctly categorizes network coverage", {
   result <- add_access_to_phone_best(df)
   result <- add_access_to_phone_coverage(result)
 
-  expect_equal(result$etc_access_to_phone_coverage, c("internet_smartphone", "no_internet_or_basic_phone", "no_internet_or_basic_phone", "no_coverage_or_no_phone", "undefined"))
+  expect_equal(
+    result$etc_access_to_phone_coverage,
+    c(
+      "internet_smartphone",
+      "no_internet_or_basic_phone",
+      "no_internet_or_basic_phone",
+      "no_coverage_or_no_phone",
+      "undefined"
+    )
+  )
 })
 
 test_that("add_access_to_phone_best handles undefined phone responses", {
@@ -45,7 +66,13 @@ test_that("add_access_to_phone_best handles undefined phone responses", {
 
 test_that("add_access_to_phone_coverage handles undefined coverage responses", {
   df_undefined <- df
-  df_undefined$etc_coverage_network_type <- c("dnk", "pnta", "dnk", "dnk", "pnta")
+  df_undefined$etc_coverage_network_type <- c(
+    "dnk",
+    "pnta",
+    "dnk",
+    "dnk",
+    "pnta"
+  )
 
   result <- add_access_to_phone_best(df_undefined)
   result <- add_access_to_phone_coverage(result)
@@ -54,7 +81,7 @@ test_that("add_access_to_phone_coverage handles undefined coverage responses", {
 })
 
 test_that("add_access_to_phone_coverage handles edge cases", {
-  df_edge <- tibble::tibble(
+  df_edge <- dplyr::tibble(
     id = 1:2,
     etc_access_to_phone = c("smartphone", "basic_phone"),
     `etc_access_to_phone/smartphone` = c(1, 0),
@@ -71,5 +98,8 @@ test_that("add_access_to_phone_coverage handles edge cases", {
   result <- add_access_to_phone_coverage(result)
 
   expect_equal(result$etc_access_to_phone_coverage[1], "internet_smartphone")
-  expect_equal(result$etc_access_to_phone_coverage[2], "no_coverage_or_no_phone")
+  expect_equal(
+    result$etc_access_to_phone_coverage[2],
+    "no_coverage_or_no_phone"
+  )
 })

--- a/tests/testthat/test-add_age_cat.R
+++ b/tests/testthat/test-add_age_cat.R
@@ -1,9 +1,5 @@
-library(testthat)
-library(tibble)
-library(humind)
-
 # Sample Data
-df <- tibble(
+df <- dplyr::tibble(
   id = 1:12,
   age = c(0, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95, 121)
 )
@@ -18,27 +14,58 @@ test_that("add_age_cat assigns correct ages to correct groups", {
   custom_breaks <- c(0, 5, 10, 18, 100)
   custom_labels <- c("0-4", "5-9", "10-17", "18-99", "100+")
 
-  result <- add_age_cat(df, "age", breaks = custom_breaks, labels = custom_labels)
+  result <- add_age_cat(
+    df,
+    "age",
+    breaks = custom_breaks,
+    labels = custom_labels
+  )
 
-  expected_categories <- c("0-4", "5-9", "10-17", "18-99", "18-99", "18-99", "18-99", "18-99", "18-99", "18-99", "18-99", "100+")
+  expected_categories <- c(
+    "0-4",
+    "5-9",
+    "10-17",
+    "18-99",
+    "18-99",
+    "18-99",
+    "18-99",
+    "18-99",
+    "18-99",
+    "18-99",
+    "18-99",
+    "100+"
+  )
 
-  expect_equal(result$age_cat, expected_categories,
-               info = "Ages should be assigned to the correct categories")
+  expect_equal(
+    result$age_cat,
+    expected_categories,
+    info = "Ages should be assigned to the correct categories"
+  )
 })
 
 test_that("add_age_cat works with custom parameters", {
   custom_breaks <- c(5, 20, 40, 60, 80, 100)
   custom_labels <- c("5-19", "20-39", "40-59", "60-79", "80-99", "100+")
-  result <- add_age_cat(df, "age", breaks = custom_breaks, labels = custom_labels)
+  result <- add_age_cat(
+    df,
+    "age",
+    breaks = custom_breaks,
+    labels = custom_labels
+  )
   expect_true("age_cat" %in% names(result))
-  expect_equal(as.vector(na.omit(unique(result$age_cat))), custom_labels,
-               info = "Levels of age_cat should match custom_labels")
+  expect_equal(
+    as.vector(na.omit(unique(result$age_cat))),
+    custom_labels,
+    info = "Levels of age_cat should match custom_labels"
+  )
 })
 
 test_that("add_age_cat handles undefined values correctly", {
-  df_with_undefined <- tibble(id = 1:3, age = c(-999, 25, 999))
+  df_with_undefined <- dplyr::tibble(id = 1:3, age = c(-999, 25, 999))
   result <- add_age_cat(df_with_undefined, "age")
-  expect_equal(result$age_cat[1], "undefined",
-               info = "Undefined values should be replaced with 'undefined'")
+  expect_equal(
+    result$age_cat[1],
+    "undefined",
+    info = "Undefined values should be replaced with 'undefined'"
+  )
 })
-

--- a/tests/testthat/test-add_comp_edu.R
+++ b/tests/testthat/test-add_comp_edu.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_data <- data.frame(
   edu_schooling_age_n = c(0, 10, 5, 7, 0, 2),

--- a/tests/testthat/test-add_comp_foodsec.R
+++ b/tests/testthat/test-add_comp_foodsec.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Create dummy data
 df_dummy <- data.frame(
   fsl_fc_phase = c("Phase 1 FC", "Phase 2 FC", "Phase 3 FC", "Phase 4 FC", "Phase 5 FC", NA)
@@ -34,5 +31,3 @@ test_that("add_comp_foodsec assigns in need status correctly", {
   result <- add_comp_foodsec(df_dummy)
   expect_equal(result$comp_foodsec_in_need, c(0, 0, 1, 1, 1, NA))
 })
-
-

--- a/tests/testthat/test-add_comp_health.R
+++ b/tests/testthat/test-add_comp_health.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Create dummy data
 df_dummy <- data.frame(
   health_ind_healthcare_needed_no_n = c(0, 1, 0, 1, 0),

--- a/tests/testthat/test-add_comp_snfi.R
+++ b/tests/testthat/test-add_comp_snfi.R
@@ -1,8 +1,3 @@
-# test_add_comp_snfi.R
-
-# Load required package
-library(testthat)
-
 # Create mock data
 test_df <- data.frame(
   snfi_shelter_type_cat = c("none", "inadequate", "adequate", "undefined"),

--- a/tests/testthat/test-add_comp_wash.R
+++ b/tests/testthat/test-add_comp_wash.R
@@ -1,70 +1,134 @@
-# Load necessary libraries
-library(testthat)
-library(dplyr)
-
-library(testthat)
-library(dplyr)
-
 # Create a sample dataset
-df_sample <- tibble::tibble(
+df_sample <- dplyr::tibble(
   setting = c("camp", "urban", "rural"),
   wash_drinking_water_quantity = c("always", "often", "rarely"),
-  wash_drinking_water_quality_jmp_cat = c("surface_water", "unimproved", "limited"),
-  wash_sanitation_facility_jmp_cat = c("open_defecation", "basic", "unimproved"),
+  wash_drinking_water_quality_jmp_cat = c(
+    "surface_water",
+    "unimproved",
+    "limited"
+  ),
+  wash_sanitation_facility_jmp_cat = c(
+    "open_defecation",
+    "basic",
+    "unimproved"
+  ),
   wash_sanitation_facility_cat = c("none", "improved", "unimproved"),
-  wash_sharing_sanitation_facility_n_ind = c("50_and_above", "20_to_49", "19_and_below"),
-  wash_sharing_sanitation_facility_cat = c("shared", "not_shared", "not_applicable"),
+  wash_sharing_sanitation_facility_n_ind = c(
+    "50_and_above",
+    "20_to_49",
+    "19_and_below"
+  ),
+  wash_sharing_sanitation_facility_cat = c(
+    "shared",
+    "not_shared",
+    "not_applicable"
+  ),
   wash_handwashing_facility_jmp_cat = c("no_facility", "basic", "limited")
 )
 
 # Test 1: Test drinking water quantity scores
 test_that("Drinking water quantity scoring works correctly", {
-  df_result <- add_comp_wash(df_sample, drinking_water_quantity = "wash_drinking_water_quantity", drinking_water_quantity_always = "always", drinking_water_quantity_often = "often", drinking_water_quantity_sometimes = "sometimes", drinking_water_quantity_rarely = "rarely", drinking_water_quantity_never = "never", drinking_water_quantity_dnk = "dnk", drinking_water_quantity_pnta = "pnta")
+  df_result <- add_comp_wash(
+    df_sample,
+    drinking_water_quantity = "wash_drinking_water_quantity",
+    drinking_water_quantity_always = "always",
+    drinking_water_quantity_often = "often",
+    drinking_water_quantity_sometimes = "sometimes",
+    drinking_water_quantity_rarely = "rarely",
+    drinking_water_quantity_never = "never",
+    drinking_water_quantity_dnk = "dnk",
+    drinking_water_quantity_pnta = "pnta"
+  )
 
-  expected_result <- c(5, 4, 2)  # Always -> 5, Often -> 4, Rarely -> 2
+  expected_result <- c(5, 4, 2) # Always -> 5, Often -> 4, Rarely -> 2
 
   expect_equal(df_result$comp_wash_score_water_quantity, expected_result)
 })
 
 # Test 2: Test drinking water quality scores based on setting
 test_that("Drinking water quality scoring works based on setting", {
-  df_result <- add_comp_wash(df_sample, setting = "setting", drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat", drinking_water_quality_jmp_cat_surface_water = "surface_water", drinking_water_quality_jmp_cat_unimproved = "unimproved", drinking_water_quality_jmp_cat_limited = "limited", drinking_water_quality_jmp_cat_basic = "basic", drinking_water_quality_jmp_cat_safely_managed = "safely_managed", drinking_water_quality_jmp_cat_undefined = "undefined")
+  df_result <- add_comp_wash(
+    df_sample,
+    setting = "setting",
+    drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat",
+    drinking_water_quality_jmp_cat_surface_water = "surface_water",
+    drinking_water_quality_jmp_cat_unimproved = "unimproved",
+    drinking_water_quality_jmp_cat_limited = "limited",
+    drinking_water_quality_jmp_cat_basic = "basic",
+    drinking_water_quality_jmp_cat_safely_managed = "safely_managed",
+    drinking_water_quality_jmp_cat_undefined = "undefined"
+  )
 
-  expected_result <- c(5, 3, 2)  # Surface water (camp) -> 5, Unimproved (urban) -> 3, Limited (rural) -> 2
+  expected_result <- c(5, 3, 2) # Surface water (camp) -> 5, Unimproved (urban) -> 3, Limited (rural) -> 2
 
   expect_equal(df_result$comp_wash_score_water_quality, expected_result)
 })
 
 # Test 3: Test sanitation score for different settings
 test_that("Sanitation scoring works correctly for different settings", {
-  df_result <- add_comp_wash(df_sample, setting = "setting", sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat", sanitation_facility_cat = "wash_sanitation_facility_cat", sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind", sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat")
+  df_result <- add_comp_wash(
+    df_sample,
+    setting = "setting",
+    sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat",
+    sanitation_facility_cat = "wash_sanitation_facility_cat",
+    sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind",
+    sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat"
+  )
 
-  expected_result <- c(5, 1, 2)  # None (camp) -> 5, Improved & Shared (urban) -> 1, Unimproved (rural) -> 2
+  expected_result <- c(5, 1, 2) # None (camp) -> 5, Improved & Shared (urban) -> 1, Unimproved (rural) -> 2
 
   expect_equal(df_result$comp_wash_score_sanitation, expected_result)
 })
 
 # Test 4: Test hygiene scoring for different settings
 test_that("Hygiene scoring works correctly", {
-  df_result <- add_comp_wash(df_sample, setting = "setting", handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat", handwashing_facility_jmp_cat_no_facility = "no_facility", handwashing_facility_jmp_cat_limited = "limited", handwashing_facility_jmp_cat_basic = "basic", handwashing_facility_jmp_cat_undefined = "undefined")
+  df_result <- add_comp_wash(
+    df_sample,
+    setting = "setting",
+    handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat",
+    handwashing_facility_jmp_cat_no_facility = "no_facility",
+    handwashing_facility_jmp_cat_limited = "limited",
+    handwashing_facility_jmp_cat_basic = "basic",
+    handwashing_facility_jmp_cat_undefined = "undefined"
+  )
 
-  expected_result <- c(3, 1, 2)  # No facility (camp) -> 3, Basic (urban) -> 1, Limited (rural) -> 2
+  expected_result <- c(3, 1, 2) # No facility (camp) -> 3, Basic (urban) -> 1, Limited (rural) -> 2
 
   expect_equal(df_result$comp_wash_score_hygiene, expected_result)
 })
 
 # Test 5: Test final composite score calculation
 test_that("Composite WASH score calculation works correctly", {
-  df_result <- add_comp_wash(df_sample, setting = "setting", drinking_water_quantity = "wash_drinking_water_quantity", drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat", sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat", sanitation_facility_cat = "wash_sanitation_facility_cat", sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind", sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat", handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat")
+  df_result <- add_comp_wash(
+    df_sample,
+    setting = "setting",
+    drinking_water_quantity = "wash_drinking_water_quantity",
+    drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat",
+    sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat",
+    sanitation_facility_cat = "wash_sanitation_facility_cat",
+    sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind",
+    sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat",
+    handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat"
+  )
 
-  expected_result <- c(5, 4, 2)  # Max of (water quantity, water quality, sanitation, hygiene) for each row
+  expected_result <- c(5, 4, 2) # Max of (water quantity, water quality, sanitation, hygiene) for each row
 
   expect_equal(df_result$comp_wash_score, expected_result)
 })
 
 # Test 6: Test if 'is_in_need' and 'is_in_acute_need' flags are correctly set
 test_that("Need flags work correctly", {
-  df_result <- add_comp_wash(df_sample, setting = "setting", drinking_water_quantity = "wash_drinking_water_quantity", drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat", sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat", sanitation_facility_cat = "wash_sanitation_facility_cat", sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind", sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat", handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat")
+  df_result <- add_comp_wash(
+    df_sample,
+    setting = "setting",
+    drinking_water_quantity = "wash_drinking_water_quantity",
+    drinking_water_quality_jmp_cat = "wash_drinking_water_quality_jmp_cat",
+    sanitation_facility_jmp_cat = "wash_sanitation_facility_jmp_cat",
+    sanitation_facility_cat = "wash_sanitation_facility_cat",
+    sanitation_facility_n_ind = "wash_sharing_sanitation_facility_n_ind",
+    sharing_sanitation_facility_cat = "wash_sharing_sanitation_facility_cat",
+    handwashing_facility_jmp_cat = "wash_handwashing_facility_jmp_cat"
+  )
 
   # Check for the 'comp_wash_in_need' and 'comp_wash_in_acute_need' columns.
   expect_true("comp_wash_in_need" %in% colnames(df_result))
@@ -75,12 +139,42 @@ test_that("Need flags work correctly", {
 undefined_water_quantity_data <- data.frame(
   setting = c("camp", "urban", "rural", "camp"),
   wash_drinking_water_quantity = c("dnk", "pnta", "never", "always"),
-  wash_drinking_water_quality_jmp_cat = c("basic", "limited", "unimproved", "safely_managed"),
-  wash_sanitation_facility_jmp_cat = c("basic", "limited", "unimproved", "safely_managed"),
-  wash_sanitation_facility_cat = c("improved", "unimproved", "none", "undefined"),
-  wash_sharing_sanitation_facility_n_ind = c("19_and_below", "20_to_49", "50_and_above", NA),
-  wash_sharing_sanitation_facility_cat = c("shared", "shared", "shared", "undefined"),
-  wash_handwashing_facility_jmp_cat = c("basic", "limited", "no_facility", "undefined")
+  wash_drinking_water_quality_jmp_cat = c(
+    "basic",
+    "limited",
+    "unimproved",
+    "safely_managed"
+  ),
+  wash_sanitation_facility_jmp_cat = c(
+    "basic",
+    "limited",
+    "unimproved",
+    "safely_managed"
+  ),
+  wash_sanitation_facility_cat = c(
+    "improved",
+    "unimproved",
+    "none",
+    "undefined"
+  ),
+  wash_sharing_sanitation_facility_n_ind = c(
+    "19_and_below",
+    "20_to_49",
+    "50_and_above",
+    NA
+  ),
+  wash_sharing_sanitation_facility_cat = c(
+    "shared",
+    "shared",
+    "shared",
+    "undefined"
+  ),
+  wash_handwashing_facility_jmp_cat = c(
+    "basic",
+    "limited",
+    "no_facility",
+    "undefined"
+  )
 )
 
 test_that("Function handles undefined water quantity correctly", {
@@ -90,9 +184,13 @@ test_that("Function handles undefined water quantity correctly", {
 
 # Test with invalid sanitation facility categories
 invalid_sanitation_data <- undefined_water_quantity_data
-invalid_sanitation_data$wash_sanitation_facility_jmp_cat <- c("invalid", "basic", "limited", "open_defecation")
+invalid_sanitation_data$wash_sanitation_facility_jmp_cat <- c(
+  "invalid",
+  "basic",
+  "limited",
+  "open_defecation"
+)
 
 test_that("Function handles invalid sanitation facility categories", {
   expect_error(add_comp_wash(invalid_sanitation_data), class = "error")
 })
-

--- a/tests/testthat/test-add_drinking_water_source_cat.R
+++ b/tests/testthat/test-add_drinking_water_source_cat.R
@@ -1,11 +1,7 @@
-# Load required libraries
-library(testthat)
-library(dplyr)
-
 # Create a comprehensive dummy data frame for testing
 # Covers all possible options for drinking water source and handwashing facility
 
-dummy_data <- tibble(
+dummy_data <- dplyr::tibble(
   survey_modality = c("in_person", "remote", "in_person", "remote"),
   wash_handwashing_facility = c("available", "no_permission", "none", "other"),
   wash_handwashing_facility_observed_water = c(

--- a/tests/testthat/test-add_expenditure_type_freq_rank.R
+++ b/tests/testthat/test-add_expenditure_type_freq_rank.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_data_top3 <- data.frame(
   uuid = 1:4,
@@ -54,4 +51,3 @@ non_numeric_data_top3$cm_expenditure_frequent_food <- as.character(non_numeric_d
 test_that("add_expenditure_type_freq_rank function checks for numeric expenditure types", {
   expect_error(add_expenditure_type_freq_rank(non_numeric_data_top3))
 })
-

--- a/tests/testthat/test-add_expenditure_type_prop_freq.R
+++ b/tests/testthat/test-add_expenditure_type_prop_freq.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_data <- data.frame(
   uuid = 1:4,

--- a/tests/testthat/test-add_expenditure_type_prop_infreq.R
+++ b/tests/testthat/test-add_expenditure_type_prop_infreq.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(dplyr)
-
-
 # Dummy data for testing
 dummy_data <- data.frame(
   uuid = 1:4,

--- a/tests/testthat/test-add_expenditure_type_zero_freq.R
+++ b/tests/testthat/test-add_expenditure_type_zero_freq.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_data <- data.frame(
   uuid = 1:4,

--- a/tests/testthat/test-add_expenditure_type_zero_infreq.R
+++ b/tests/testthat/test-add_expenditure_type_zero_infreq.R
@@ -1,9 +1,5 @@
-# Load required libraries
-library(testthat)
-library(dplyr)
-
 # Create dummy data for testing
-df <- tibble(
+df <- dplyr::tibble(
   cm_expenditure_frequent = c("no", "no", "no", "no", "no"),
   cm_expenditure_infrequent = c("shelter", "none", "dnk", "pnta", "education"),
   cm_expenditure_infrequent_shelter = c(500, 0, 0, 0, 0),

--- a/tests/testthat/test-add_fds_cannot_cat.R
+++ b/tests/testthat/test-add_fds_cannot_cat.R
@@ -1,13 +1,8 @@
-# Load required libraries
-library(dplyr)
-library(testthat)
-library(tibble)
-
 # ---- The function under test (reference, not redefined here) ----
 # add_fds_cannot_cat is assumed to be already available in your environment
 
 # ---- Example data ----
-test_df <- tibble(
+test_df <- dplyr::tibble(
   snfi_fds_cooking = c("no", "yes", "no_need", "pnta", "yes"),
   snfi_fds_sleeping = c("yes", "no", "pnta", "yes", "no"),
   snfi_fds_storing = c("yes_no_issues", "no", "yes_issues", "pnta", "no"),

--- a/tests/testthat/test-add_handwashing_facility_cat.R
+++ b/tests/testthat/test-add_handwashing_facility_cat.R
@@ -1,9 +1,15 @@
-library(testthat)
-library(dplyr)
-
 test_that("add_handwashing_facility_cat categorizes correctly", {
   test_df <- dplyr::tibble(
-    survey_modality = c("in_person", "in_person", "in_person", "in_person", "remote", "remote", "in_person", "in_person"),
+    survey_modality = c(
+      "in_person",
+      "in_person",
+      "in_person",
+      "in_person",
+      "remote",
+      "remote",
+      "in_person",
+      "in_person"
+    ),
     wash_handwashing_facility = c(
       "available_fixed_in_dwelling",
       "available_fixed_in_plot",
@@ -15,24 +21,65 @@ test_that("add_handwashing_facility_cat categorizes correctly", {
       "other"
     ),
     wash_handwashing_facility_observed_water = c(
-      "water_available", "water_not_available", "water_available", "water_available", NA, NA, NA, "water_available"
+      "water_available",
+      "water_not_available",
+      "water_available",
+      "water_available",
+      NA,
+      NA,
+      NA,
+      "water_available"
     ),
     wash_soap_observed = c(
-      "yes_soap_shown", "yes_soap_shown", "no", "yes_soap_shown", NA, NA, NA, "yes_soap_shown"
+      "yes_soap_shown",
+      "yes_soap_shown",
+      "no",
+      "yes_soap_shown",
+      NA,
+      NA,
+      NA,
+      "yes_soap_shown"
     ),
     wash_handwashing_facility_reported = c(
-      NA, NA, NA, NA, "fixed_dwelling", "none", "mobile", "other"
+      NA,
+      NA,
+      NA,
+      NA,
+      "fixed_dwelling",
+      "none",
+      "mobile",
+      "other"
     ),
     wash_handwashing_facility_water_reported = c(
-      NA, NA, NA, NA, "yes", "no", "yes", "dnk"
+      NA,
+      NA,
+      NA,
+      NA,
+      "yes",
+      "no",
+      "yes",
+      "dnk"
     ),
     wash_soap_reported = c(
-      NA, NA, NA, NA, "yes", "no", "yes", "dnk"
+      NA,
+      NA,
+      NA,
+      NA,
+      "yes",
+      "no",
+      "yes",
+      "dnk"
     )
   )
   expected <- c(
-    "basic", "limited", "limited", "no_facility",
-    "basic", "limited", "basic", "undefined"
+    "basic",
+    "limited",
+    "limited",
+    "no_facility",
+    "basic",
+    "limited",
+    "basic",
+    "undefined"
   )
   result_df <- add_handwashing_facility_cat(test_df)
   expect_equal(result_df$wash_handwashing_facility_jmp_cat, expected)

--- a/tests/testthat/test-add_hoh_final.R
+++ b/tests/testthat/test-add_hoh_final.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Mock the helper functions if_not_in_stop and are_values_in_set
 if_not_in_stop <- function(df, cols, df_name) {
   missing_cols <- setdiff(cols, colnames(df))
@@ -102,4 +99,3 @@ test_that("add_hoh_final handles non-numeric age variables", {
   expect_error(add_hoh_final(df), class = "error")
 
 })
-

--- a/tests/testthat/test-add_income_source_prop.R
+++ b/tests/testthat/test-add_income_source_prop.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(dplyr)
-library(humind)
-
 test_that("Correct column names are added to the output", {
   df <- data.frame(
     cm_income_source_salaried_n = c(100, 200),
@@ -138,4 +134,3 @@ test_that("Throws an error if columns are not numeric", {
 
   expect_error(add_income_source_prop(df), "numeric")
 })
-

--- a/tests/testthat/test-add_income_source_rank.R
+++ b/tests/testthat/test-add_income_source_rank.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 df <- data.frame(
   uuid = 1:3,
   cm_income_source_assistance_n = c(50, 0, 0),
@@ -16,20 +13,30 @@ df <- data.frame(
   cm_income_source_other_n = c(0, 60, 0)
 )
 test_that("add_income_source_rank returns correct structure", {
-  result <- add_income_source_rank(df)
+  result <- suppressWarnings(
+    add_income_source_rank(df)
+  )
 
   # Test that the result is a data frame
   expect_s3_class(result, "data.frame")
 
   # Test that the new columns are present
-  expect_true(all(c("cm_income_source_emergency_n", "cm_income_source_unstable_n",
-                    "cm_income_source_stable_n", "cm_income_source_other_n",
-                    "cm_income_source_top1", "cm_income_source_top2",
-                    "cm_income_source_top3") %in% names(result)))
+  expect_true(all(
+    c(
+      "cm_income_source_emergency_n",
+      "cm_income_source_unstable_n",
+      "cm_income_source_stable_n",
+      "cm_income_source_other_n",
+      "cm_income_source_top1",
+      "cm_income_source_top2",
+      "cm_income_source_top3"
+    ) %in%
+      names(result)
+  ))
 })
 
 test_that("add_income_source_rank returns correct values", {
-  result <- add_income_source_rank(df)
+  result <- suppressWarnings(add_income_source_rank(df))
 
   # Test that the counts are correct
   expect_equal(result$cm_income_source_emergency_n, c(2, 2, 1))
@@ -38,9 +45,15 @@ test_that("add_income_source_rank returns correct values", {
   expect_equal(result$cm_income_source_other_n, c(0, 1, 0))
 
   # Test that the final categories are correct
-  expect_equal(result$cm_income_source_top1, c("stable", "emergency", "unstable"))
+  expect_equal(
+    result$cm_income_source_top1,
+    c("stable", "emergency", "unstable")
+  )
   expect_equal(result$cm_income_source_top2, c("unstable", "stable", "stable"))
-  expect_equal(result$cm_income_source_top3, c("emergency", "unstable", "stable"))
+  expect_equal(
+    result$cm_income_source_top3,
+    c("emergency", "unstable", "stable")
+  )
 })
 
 test_that("add_income_source_rank handles missing columns gracefully", {
@@ -50,15 +63,30 @@ test_that("add_income_source_rank handles missing columns gracefully", {
 
 test_that("add_income_source_rank handles non-numeric columns gracefully", {
   df_non_numeric <- df %>%
-    mutate(cm_income_source_assistance_n = as.character(cm_income_source_assistance_n))
+    mutate(
+      cm_income_source_assistance_n = as.character(
+        cm_income_source_assistance_n
+      )
+    )
   expect_error(add_income_source_rank(df_non_numeric), class = "error")
 })
 
 
 # Sample data frame
 df <- data.frame(
-  cm_income_source_top1 = c("cm_income_source_assistance_n", "cm_income_source_salaried_n", "cm_income_source_rent_n"),
-  cm_income_source_top2 = c("cm_income_source_social_benefits_n", "cm_income_source_support_friends_n", "cm_income_source_own_business_n"),
-  cm_income_source_top3 = c("cm_income_source_donation_n", "cm_income_source_own_production_n", "cm_income_source_other_n")
+  cm_income_source_top1 = c(
+    "cm_income_source_assistance_n",
+    "cm_income_source_salaried_n",
+    "cm_income_source_rent_n"
+  ),
+  cm_income_source_top2 = c(
+    "cm_income_source_social_benefits_n",
+    "cm_income_source_support_friends_n",
+    "cm_income_source_own_business_n"
+  ),
+  cm_income_source_top3 = c(
+    "cm_income_source_donation_n",
+    "cm_income_source_own_production_n",
+    "cm_income_source_other_n"
+  )
 )
-

--- a/tests/testthat/test-add_income_source_zero_to_sl.R
+++ b/tests/testthat/test-add_income_source_zero_to_sl.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Sample data frame
 df <- data.frame(
   uuid = 1:3,

--- a/tests/testthat/test-add_loop_age_dummy.R
+++ b/tests/testthat/test-add_loop_age_dummy.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Mock the helper functions if_not_in_stop and are_cols_numeric
 if_not_in_stop <- function(df, cols, df_name) {
   missing_cols <- setdiff(cols, colnames(df))
@@ -125,4 +122,3 @@ test_that("add_loop_age_gender_dummy_to_main works with default parameters", {
 
   expect_equal(result, expected)
 })
-

--- a/tests/testthat/test-add_loop_edu_access_d.R
+++ b/tests/testthat/test-add_loop_edu_access_d.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_loop_data <- data.frame(
   uuid = c(1, 1, 2, 2, 3, 4),

--- a/tests/testthat/test-add_loop_edu_barrier_protection_d.R
+++ b/tests/testthat/test-add_loop_edu_barrier_protection_d.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(dplyr)
-
-
 # Dummy data for testing
 dummy_loop_data <- data.frame(
   uuid = c(1, 1, 2, 2, 3, 4),

--- a/tests/testthat/test-add_loop_edu_disrupted_d.R
+++ b/tests/testthat/test-add_loop_edu_disrupted_d.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_loop_data <- data.frame(
   uuid = c(1, 1, 2, 2, 3, 4),

--- a/tests/testthat/test-add_loop_edu_ind_age_corrected.R
+++ b/tests/testthat/test-add_loop_edu_ind_age_corrected.R
@@ -1,14 +1,10 @@
-# Load required libraries
-library(testthat)
-library(dplyr)
-
 # Create dummy data for testing
-loop_data <- tibble(
+loop_data <- dplyr::tibble(
   uuid = c("id1", "id2", "id3", "id4"),
   ind_age = c(10, 12, 18, 3)
 )
 
-main_data <- tibble(
+main_data <- dplyr::tibble(
   uuid = c("id1", "id2", "id3", "id4"),
   start = as.Date(c("2023-01-15", "2023-02-20", "2023-03-25", "2023-04-30"))
 )
@@ -25,7 +21,11 @@ test_that("Function handles specific month correctly", {
 })
 
 test_that("Function handles school year start month correctly", {
-  result <- add_loop_edu_ind_age_corrected(loop_data, main_data, school_year_start_month = 1)
+  result <- add_loop_edu_ind_age_corrected(
+    loop_data,
+    main_data,
+    school_year_start_month = 1
+  )
   expect_equal(result$edu_ind_age_corrected, c(10, 12, NA, NA))
 })
 
@@ -58,4 +58,3 @@ test_that("Function calculates number of school-age children correctly", {
   main_result <- add_loop_edu_ind_schooling_age_d_to_main(main_data, result)
   expect_equal(main_result$edu_schooling_age_n, c(1, 1, 0, 0))
 })
-

--- a/tests/testthat/test-add_loop_healthcare_needed_cat.R
+++ b/tests/testthat/test-add_loop_healthcare_needed_cat.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 # Sample data for testing
 loop <- data.frame(
   uuid = c(1, 2, 3, 4, 5, 6),
@@ -44,7 +42,10 @@ test_that("healthcare needed categories are calculated correctly", {
 # Test with default parameters for add_loop_healthcare_needed_cat_main
 test_that("add_loop_healthcare_needed_cat_main works with default parameters", {
   loop_result <- add_loop_healthcare_needed_cat(loop)
-  result <- add_loop_healthcare_needed_cat_to_main(main, loop_result)
+  result <- suppressWarnings(add_loop_healthcare_needed_cat_to_main(
+    main,
+    loop_result
+  ))
   expect_true(all(
     c(
       "health_ind_healthcare_needed_no_n",
@@ -80,7 +81,10 @@ test_that("id columns are correctly handled", {
 # Test if main data frame correctly joins with loop data frame
 test_that("main data frame correctly joins with loop data frame", {
   loop_result <- add_loop_healthcare_needed_cat(loop)
-  result <- add_loop_healthcare_needed_cat_to_main(main, loop_result)
+  result <- suppressWarnings(add_loop_healthcare_needed_cat_to_main(
+    main,
+    loop_result
+  ))
   expect_equal(result$health_ind_healthcare_needed_no_n, c(0, 1, 0, 0, 0, 1))
   expect_equal(
     result$health_ind_healthcare_needed_yes_unmet_n,
@@ -97,12 +101,12 @@ test_that("it works if UUID columns are named X_UUID in main, and X_SUB_UUID in 
   main$X_UUID <- c(1, 2, 3, 4, 5, 6)
   loop$X_SUB_UUID <- c(1, 2, 3, 4, 5, 6)
   loop_result <- add_loop_healthcare_needed_cat(loop)
-  result <- add_loop_healthcare_needed_cat_to_main(
+  result <- suppressWarnings(add_loop_healthcare_needed_cat_to_main(
     main,
     loop_result,
     id_col_main = "X_UUID",
     id_col_loop = "X_SUB_UUID"
-  )
+  ))
   expect_equal(result$health_ind_healthcare_needed_no_n, c(0, 1, 0, 0, 0, 1))
   expect_equal(
     result$health_ind_healthcare_needed_yes_unmet_n,

--- a/tests/testthat/test-add_loop_wgq_ss.R
+++ b/tests/testthat/test-add_loop_wgq_ss.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # test_that("add_loop_wgq_ss works with different levels of difficulty", {
 #   df <- data.frame(
 #     ind_age = c(10, 12, 7, 6, 20),

--- a/tests/testthat/test-add_msni.R
+++ b/tests/testthat/test-add_msni.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 test_that("add_msni works with default parameters", {
   df <- data.frame(
     comp_foodsec_score = c(1, 2, 3, 4, 5),

--- a/tests/testthat/test-add_occupancy_cat.R
+++ b/tests/testthat/test-add_occupancy_cat.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 # Example data frame covering all combinations
 example_df <- data.frame(
   hlp_occupancy = c(

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -112,7 +112,7 @@ test_that("composite severity is bounded 1–4", {
     dummy_df[[str_glue("{q2}/pnta")]] == 1)
 
   # Flagged rows should be NA
-  expect_true(all(is.na(res$comp_prot_score_needs_2[flagged])))
+  expect_true(all(is.na(res$comp_prot_score_practices[flagged])))
   expect_true(all(res$comp_prot_score_practices >= 1, na.rm = TRUE))
   expect_true(all(res$comp_prot_score_practices <= 4, na.rm = TRUE))
 })

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -1,5 +1,3 @@
-library(tidyr)
-
 q1 <- "prot_needs_2_activities"
 q2 <- "prot_needs_2_social"
 

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -46,7 +46,7 @@ dummy_social <- generate_survey_choice_combinations(
 (dummy_df <- expand_grid(
   dummy_activities,
   dummy_social,
-  .name_repair = "unique"
+  .name_repair = "unique_quiet"
 ) |>
   dplyr::as_tibble())
 

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -48,7 +48,7 @@ dummy_social <- generate_survey_choice_combinations(
   dummy_social,
   .name_repair = "unique"
 ) |>
-  as_tibble())
+  dplyr::as_tibble())
 
 # Tests for the composite function
 

--- a/tests/testthat/test-add_prot_score_rights.R
+++ b/tests/testthat/test-add_prot_score_rights.R
@@ -123,7 +123,7 @@ test_that("composite severity: NA for DNK/P NTA, 1–4 for others, and non-destr
     dummy_df[[str_glue("{q2}/pnta")]] == 1)
 
   # Flagged rows should be NA
-  expect_true(all(is.na(res$comp_prot_score_needs_1[flagged])))
+  expect_true(all(is.na(res$comp_prot_score_rights[flagged])))
 
   # Non-flagged rows should be bounded between 1 and 4
   expect_true(all(res$comp_prot_score_rights[!flagged] >= 1, na.rm = TRUE))

--- a/tests/testthat/test-add_prot_score_rights.R
+++ b/tests/testthat/test-add_prot_score_rights.R
@@ -43,7 +43,7 @@ dummy_justice <- generate_survey_choice_combinations(
 dummy_df <- expand_grid(
   dummy_services,
   dummy_justice,
-  .name_repair = "unique"
+  .name_repair = "unique_quiet"
 ) |>
   dplyr::as_tibble()
 

--- a/tests/testthat/test-add_prot_score_rights.R
+++ b/tests/testthat/test-add_prot_score_rights.R
@@ -1,5 +1,3 @@
-library(tidyr)
-
 # Build dummy data for access to rights and services indicator
 q1 <- "prot_needs_1_services"
 q2 <- "prot_needs_1_justice"

--- a/tests/testthat/test-add_prot_score_rights.R
+++ b/tests/testthat/test-add_prot_score_rights.R
@@ -45,7 +45,7 @@ dummy_df <- expand_grid(
   dummy_justice,
   .name_repair = "unique"
 ) |>
-  as_tibble()
+  dplyr::as_tibble()
 
 # Tests for the composite function: Ability to Access Rights and Services
 

--- a/tests/testthat/test-add_quantile_interval.R
+++ b/tests/testthat/test-add_quantile_interval.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(dplyr)
-
-
-
 test_that("add_quantile_interval works with default parameters", {
 
   df <- data.frame(
@@ -97,4 +92,3 @@ test_that("add_quantile_interval handles missing weight column", {
   expect_error(add_quantile_interval(df, vars = c("num_col1", "num_col2"), weight = "weights"), class = "error")
 
 })
-

--- a/tests/testthat/test-add_received_assistance.R
+++ b/tests/testthat/test-add_received_assistance.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 test_that("add_received_assistance works with default parameters", {
   df <- data.frame(
     aap_received_assistance_12m = c("yes", "no", "dnk", "pnta"),

--- a/tests/testthat/test-add_sanitation_facility_cat.R
+++ b/tests/testthat/test-add_sanitation_facility_cat.R
@@ -1,9 +1,3 @@
-# tests/testthat/test-sanitation_facility_classification.R
-
-library(testthat)
-library(dplyr)
-
-
 # Sample data for testing
 df <- data.frame(
   wash_sanitation_facility = c("flush_piped_sewer", "flush_piped_sewer", "flush_open_drain", "none", "other", "pit_latrine_wo_slab"),

--- a/tests/testthat/test-add_shelter_damage_cat.R
+++ b/tests/testthat/test-add_shelter_damage_cat.R
@@ -1,7 +1,3 @@
-# Load required packages
-library(testthat)
-library(dplyr)
-
 # Test data frame with all cases
 df <- data.frame(
   "snfi_shelter_damage/none" = c(1, 0, 0, 0, 0, 0, 0, 0, 0, 0),

--- a/tests/testthat/test-add_shelter_issue_cat.R
+++ b/tests/testthat/test-add_shelter_issue_cat.R
@@ -1,7 +1,3 @@
-# Load testthat
-library(testthat)
-
-# ---- Test Data ----
 test_df <- data.frame(
   snfi_shelter_issue = rep(NA, 8),
   "snfi_shelter_issue/lack_privacy" = c(1, 0, 0, 0, 0, 0, 0, 1),
@@ -21,41 +17,29 @@ test_df <- data.frame(
   "snfi_shelter_issue/other" = c(0, 0, 0, 0, 1, 0, 0, 0),
   check.names = FALSE
 )
-# ---- Expected Output ----
-# Row 1: 1 issue selected -> "1_to_3"
-# Row 2: 2 issues selected -> "1_to_3"
-# Row 3: 2 issues selected -> "1_to_3"
-# Row 4: 7 issues selected -> "4_to_7"
-# Row 5: 'other' selected -> "other"
-# Row 6: 'none' selected -> "none"
-# Row 7: 'dnk' selected -> "undefined"
-# Row 8: 11 issues selected -> "8_to_11"
 
-# ---- Run the function ----
-result <- add_shelter_issue_cat(
-  df = test_df,
-  shelter_issue = "snfi_shelter_issue",
-  none = "none",
-  issues = c(
-    "lack_privacy",
-    "lack_space",
-    "temperature",
-    "ventilation",
-    "vectors",
-    "no_natural_light",
-    "leak",
-    "lock",
-    "lack_lighting",
-    "difficulty_move",
-    "lack_space_laundry"
-  ),
-  undefined = c("dnk", "pnta"),
-  other = c("other"),
-  sep = "/"
-)
-
-# ---- Unit Tests ----
 test_that("snfi_shelter_issue_n and snfi_shelter_issue_cat are correct for all scenarios", {
+  result <- add_shelter_issue_cat(
+    df = test_df,
+    shelter_issue = "snfi_shelter_issue",
+    none = "none",
+    issues = c(
+      "lack_privacy",
+      "lack_space",
+      "temperature",
+      "ventilation",
+      "vectors",
+      "no_natural_light",
+      "leak",
+      "lock",
+      "lack_lighting",
+      "difficulty_move",
+      "lack_space_laundry"
+    ),
+    undefined = c("dnk", "pnta"),
+    other = c("other"),
+    sep = "/"
+  )
   expect_equal(result$snfi_shelter_issue_n, c(1, 2, 2, 7, NA, 0, NA, 11))
   expect_equal(
     result$snfi_shelter_issue_cat,

--- a/tests/testthat/test-add_shelter_type_cat.R
+++ b/tests/testthat/test-add_shelter_type_cat.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 test_that("add_shelter_type_cat works with different shelter types", {
   df <- data.frame(
     snfi_shelter_type = c("none", "collective_center", "pnta", "other", "individual_shelter"),

--- a/tests/testthat/test-count_if_above_zero.R
+++ b/tests/testthat/test-count_if_above_zero.R
@@ -1,9 +1,3 @@
-# tests/testthat/test-count_if_above_zero.R
-
-library(testthat)
-library(dplyr)
-
-
 # Sample data for testing
 df <- data.frame(
   var1 = c(1, 0, -1, 3, 0),

--- a/tests/testthat/test-impute_value.R
+++ b/tests/testthat/test-impute_value.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(dplyr)
-
-
 test_that("impute_value works with default parameters", {
   df <- data.frame(
     var1 = c(1, 2, NA, 4),

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Test data
 df <- data.frame(
   col1 = c(1, 2, 3, 4, NA),

--- a/tests/testthat/test-is_in_need.R
+++ b/tests/testthat/test-is_in_need.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Example test data
 df <- data.frame(
   score = c(1, 2, 3, 4, 5),
@@ -39,11 +36,8 @@ test_that("is_in_need creates a new column with custom name", {
 
 test_that("is_in_need warns when new column name already exists", {
   df$score_in_need <- rep(0, nrow(df))
-  withCallingHandlers(
+  expect_warning(
     is_in_need(df, "score"),
-    warning = function(w) {
-      expect_match(w$message, "score_in_need already exists in the data frame.")
-    }
+    "score_in_need already exists in the data frame."
   )
 })
-

--- a/tests/testthat/test-num_cat.R
+++ b/tests/testthat/test-num_cat.R
@@ -1,13 +1,7 @@
-# tests/testthat/test-num_cat.R
-
-library(testthat)
-library(dplyr)
-
 # Dummy data for testing
 dummy_data <- data.frame(
   num_col = c(1, 5, 10, 15, 20, 25, -999, 999, NA),
   num_col2 = c(1, 5, 10, 15, 20, 25, 60, 30, NA)
-
 )
 
 # 1. Test the function with default parameters
@@ -24,7 +18,13 @@ undefined_data <- data.frame(
 
 test_that("Function handles undefined values", {
   breaks <- c(0, 10, 20)
-  result <- num_cat(undefined_data, "num_col", breaks, int_undefined = c(-999, 999), char_undefined = "Unknown")
+  result <- num_cat(
+    undefined_data,
+    "num_col",
+    breaks,
+    int_undefined = c(-999, 999),
+    char_undefined = "Unknown"
+  )
   expect_true(all(result$num_col_cat == "Unknown"))
 })
 
@@ -86,6 +86,11 @@ custom_colname_data <- dummy_data
 
 test_that("Function handles custom new column name", {
   breaks <- c(0, 10, 20)
-  result <- num_cat(custom_colname_data, "num_col", breaks, new_colname = "custom_col")
+  result <- num_cat(
+    custom_colname_data,
+    "num_col",
+    breaks,
+    new_colname = "custom_col"
+  )
   expect_true("custom_col" %in% colnames(result))
 })

--- a/tests/testthat/test-rank_top3_vars.R
+++ b/tests/testthat/test-rank_top3_vars.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(humind)
-
 # Sample data frame
 df <- data.frame(
   uuid = 1:3,

--- a/tests/testthat/test-reexport-impactR4PHU.R
+++ b/tests/testthat/test-reexport-impactR4PHU.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(humind)
-
 test_that("Reexport functions are available", {
   expect_true(exists("add_hhs"))
   expect_true(exists("add_fcs"))

--- a/tests/testthat/test-sum_vars.R
+++ b/tests/testthat/test-sum_vars.R
@@ -1,6 +1,3 @@
-library(testthat)
-library(dplyr)
-
 # Sample data for testing
 df <- data.frame(
   var1 = c(1, 2, 3, NA, 5),

--- a/tests/testthat/test-value_to_sl.R
+++ b/tests/testthat/test-value_to_sl.R
@@ -1,8 +1,5 @@
-library(testthat)
-library(dplyr)
-
 # Sample data for testing
-df <- tibble::tibble(
+df <- dplyr::tibble(
   id = 1:4,
   var = c("a", "b", NA, "d"),
   sl_var1 = c(NA, 2, NA, 4),
@@ -10,28 +7,53 @@ df <- tibble::tibble(
 )
 
 test_that("value_to_sl adds sl_value correctly", {
-  result <- value_to_sl(df, var = "var", undefined = c("a", "d"), sl_vars = c("sl_var1", "sl_var2"), sl_value = 10)
+  result <- value_to_sl(
+    df,
+    var = "var",
+    undefined = c("a", "d"),
+    sl_vars = c("sl_var1", "sl_var2"),
+    sl_value = 10
+  )
 
   expect_equal(result$sl_var1, c(NA, 2, 10, 4))
   expect_equal(result$sl_var2, c(NA, 10, 3, 4))
 })
 
 test_that("value_to_sl skips adding sl_value when var is undefined", {
-  result <- value_to_sl(df, var = "var", undefined = c("a", "d"), sl_vars = c("sl_var1", "sl_var2"), sl_value = 10)
+  result <- value_to_sl(
+    df,
+    var = "var",
+    undefined = c("a", "d"),
+    sl_vars = c("sl_var1", "sl_var2"),
+    sl_value = 10
+  )
 
   expect_equal(result$sl_var1, c(NA, 2, 10, 4))
   expect_equal(result$sl_var2, c(NA, 10, 3, 4))
 })
 
 test_that("value_to_sl handles non-NA sl_vars correctly", {
-  result <- value_to_sl(df, var = "var", undefined = NULL, sl_vars = c("sl_var1", "sl_var2"), sl_value = 10)
+  result <- value_to_sl(
+    df,
+    var = "var",
+    undefined = NULL,
+    sl_vars = c("sl_var1", "sl_var2"),
+    sl_value = 10
+  )
 
   expect_equal(result$sl_var1, c(10, 2, 10, 4))
   expect_equal(result$sl_var2, c(10, 10, 3, 4))
 })
 
 test_that("value_to_sl adds suffix to new variable names", {
-  result <- value_to_sl(df, var = "var", undefined = NULL, sl_vars = c("sl_var1", "sl_var2"), sl_value = 10, suffix = "_new")
+  result <- value_to_sl(
+    df,
+    var = "var",
+    undefined = NULL,
+    sl_vars = c("sl_var1", "sl_var2"),
+    sl_value = 10,
+    suffix = "_new"
+  )
 
   expect_equal(result$sl_var1_new, c(10, 2, 10, 4))
   expect_equal(result$sl_var2_new, c(10, 10, 3, 4))


### PR DESCRIPTION
### **Summary**
This PR focuses on:
- Cleaning up unit tests (removing irrelevant warnings, improving coverage).
- Making dependencies explicit and minimal.
- Fixing documentation issues.
- Resolving several open issues related to R CMD check warnings and test reliability.

---

## **Changelog**

### ✅ **Enhancements & Fixes**
- **Unit Tests**
  - Improved and expanded tests for:
    - `add_shelter_issue_cat` – handled `tidyselect` warnings and moved calls inside `test_that`.
    - `add_prot_score_rights` and `add_prot_score_practices` – corrected column names.
    - `add_occupancy_cat` – added edge case coverage and category combinations.
  - Addressed warnings in tests:
    - Explicit handling of `NA` vectors in `max()` to avoid warnings.
    - Silenced `.name_repair` warnings from `tidyr` using `.name_repair = "unique_quiet"`.
    - Suppressed expected but irrelevant warnings in unrelated tests.
  - Improved reliability by using `testthat::expect_warning()` for warnings.

- **Dependencies**
  - Removed unused dependency. (**Closes #624**)
  - Eliminated implicit dependency on `tibble`. (**Closes #626**)
  - Updated dependency to `impactR.utils` fork by `impact-initiatives`. (**Closes #596**)
  - Ensured `tidyr` is loaded for tests.

- **Documentation**
  - Fixed `roxygen2` formatting for `add_comp_snfi`.
  - Completed documentation for argument `shelter_damage`.
  - Updated documentation for `add_shelter_issue_cat` (arguments, return values, category logic).

- **Code Quality**
  - General formatting and cleanup across R scripts and test files.
  - Removed outdated and redundant tests related to drinking water source categorization (context from #620).

### ✅ **Temporary Fix**
- Commented out failing test for `add_loop_wgq_ss` pending confirmation on WGQ removal.

---

## **Issues Resolved**
- **#596** – Depend on internal fork of `impactR.utils`.
- **#624** – Remove unused dependency.
- **#626** – Remove implicit dependency on `tibble`.
- **#628** – Update tests and suppress irrelevant warnings.
- **#620 (partial)** – Fix failing tests by removing outdated ones and improving relevant tests.

---
