### PR TITLE
Fix/v2025.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ inst/doc
 
 # pkgdown folder
 pkgdown/
+
+# Ignore README.HTML
+README.html

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ URL: https://github.com/impact-initiatives-hppu/humind
 BugReports: https://github.com/impact-initiatives-hppu/humind/issues
 Remotes: 
     impact-initiatives/impactR.utils,
-    impact-initiatives/impactR4PHU
+    impact-initiatives/impactR4PHU@v2025.1.0-legacy
 Suggests: 
     rmarkdown,
     roxygen2,

--- a/README.Rmd
+++ b/README.Rmd
@@ -110,8 +110,7 @@ Open a **[blank issue](https://github.com/impact-initiatives-hppu/humind/issues/
 When installing the package from GitHub using `devtools::install_github()`, you may encounter an error such as:
 
 ```r
-# install.packages("devtools")
-devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
+> devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
 
 Using GitHub PAT from the git credential store.
 Error : Failed to install 'unknown package' from GitHub:

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,13 +103,16 @@ Open a **[blank issue](https://github.com/impact-initiatives-hppu/humind/issues/
 ---
 
 
-## Known Issues
+## ⚠️ Known Issues
 
 ### GitHub Credentials Error When Installing with devtools
 
 When installing the package from GitHub using `devtools::install_github()`, you may encounter an error such as:
 
-```
+```r
+# install.packages("devtools")
+devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
+
 Using GitHub PAT from the git credential store.
 Error : Failed to install 'unknown package' from GitHub:
   HTTP error 401.

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,7 +37,7 @@ The package follows the 'Step - Composition' approach of IMPACT R framework.
 You can install the latest stable version of `humind` from GitHub:
 
 ``` r
-install.packages("devtools")
+# install.packages("devtools")
 devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
 ```
 
@@ -50,7 +50,7 @@ packageVersion("humind")
 
 ## 📚 Guidance Note
 
-A comprehensive **Guidance Note** is available [on SharePoint](https://acted.sharepoint.com/sites/IMPACT-Humanitarian_Planning_Prioritization/SitePages/MSNA%20analysis%20(LSG-MSNi).aspx?xsdata=MDV8MDJ8fDE5ZmZkZDBlMTgyYTQ5MWUxNjUzMDhkZGNlNmVmOGYxfGQyMDBlOTAzMTliMDQ1MmViZDIxZDFhYTAxMTM5MGQ1fDB8MHw2Mzg4OTM2OTgxNzQ3NTIzMzl8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T21FM01HUmpZV0V4TURVNU5qUTVaV0ZpTXpRek1HTmpPR1F3WWpVeU1UQXhRSFJvY21WaFpDNTJNaTl0WlhOellXZGxjeTh4TnpVek56Y3pNREUyTmpjMHw5Y2NhODkyYzY5Yzc0ZmM5YWFkZjA4ZGRjZTZlZjhmMHxjODMwNzNhMzEzYWM0MGQ3ODRjNDhlODNlM2ViNTMyNQ%3D%3D&sdata=UlNiOVVRdGoxSC9QYmg4SW1Hb1ppUmlCNi8wZ2xPMGZkdG8rYzcrU2ptND0%3D&ovuser=d200e903-19b0-452e-bd21-d1aa011390d5%2Cquentin.villotta%40impact-initiatives.org&OR=Teams-HL&CT=1753776647777&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTA3MDMxODgwOSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D) for all users of the `humind` package. This document provides essential background on the **MSNI framework** and includes sector-specific guidance.
+A comprehensive **Guidance Note** is available [here](https://acted.sharepoint.com/sites/IMPACT-Humanitarian_Planning_Prioritization/SitePages/MSNA%20analysis%20(LSG-MSNi).aspx?xsdata=MDV8MDJ8fDE5ZmZkZDBlMTgyYTQ5MWUxNjUzMDhkZGNlNmVmOGYxfGQyMDBlOTAzMTliMDQ1MmViZDIxZDFhYTAxMTM5MGQ1fDB8MHw2Mzg4OTM2OTgxNzQ3NTIzMzl8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T21FM01HUmpZV0V4TURVNU5qUTVaV0ZpTXpRek1HTmpPR1F3WWpVeU1UQXhRSFJvY21WaFpDNTJNaTl0WlhOellXZGxjeTh4TnpVek56Y3pNREUyTmpjMHw5Y2NhODkyYzY5Yzc0ZmM5YWFkZjA4ZGRjZTZlZjhmMHxjODMwNzNhMzEzYWM0MGQ3ODRjNDhlODNlM2ViNTMyNQ%3D%3D&sdata=UlNiOVVRdGoxSC9QYmg4SW1Hb1ppUmlCNi8wZ2xPMGZkdG8rYzcrU2ptND0%3D&ovuser=d200e903-19b0-452e-bd21-d1aa011390d5%2Cquentin.villotta%40impact-initiatives.org&OR=Teams-HL&CT=1753776647777&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTA3MDMxODgwOSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D) for all users of the `humind` package. This document provides essential background on the **MSNI framework** and includes sector-specific guidance.
 Each sector includes a **"Humind Data Workflow"** section, guiding users through the necessary steps and highlighting the relevant `humind` package functions to use.
 
 > ⚠️ **Users are strongly encouraged to thoroughly read this document** — particularly the *Data Workflow* sections — before starting any implementation work with Humind

--- a/README.Rmd
+++ b/README.Rmd
@@ -102,6 +102,31 @@ Open a **[blank issue](https://github.com/impact-initiatives-hppu/humind/issues/
 
 ---
 
+
+## Known Issues
+
+### GitHub Credentials Error When Installing with devtools
+
+When installing the package from GitHub using `devtools::install_github()`, you may encounter an error such as:
+
+```
+Using GitHub PAT from the git credential store.
+Error : Failed to install 'unknown package' from GitHub:
+  HTTP error 401.
+  Bad credentials
+```
+
+This issue is typically caused by outdated or incorrect GitHub credentials stored in R. For public repositories, no credentials are required. To resolve this, you can either update your credentials or delete the stored credentials using the following commands:
+
+```r
+library(gitcreds)
+gitcreds_delete()
+```
+
+After updating or deleting the credentials, retry the installation. This should resolve the error for public repositories.
+
+---
+
 ## License
 
 `humind` is released under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ When installing the package from GitHub using
 `devtools::install_github()`, you may encounter an error such as:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
+> devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
 
 Using GitHub PAT from the git credential store.
 Error : Failed to install 'unknown package' from GitHub:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ framework.
 You can install the latest stable version of `humind` from GitHub:
 
 ``` r
-install.packages("devtools")
+# install.packages("devtools")
 devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
 ```
 
@@ -46,8 +46,8 @@ packageVersion("humind")
 
 ## 📚 Guidance Note
 
-A comprehensive **Guidance Note** is available [on
-SharePoint](https://acted.sharepoint.com/sites/IMPACT-Humanitarian_Planning_Prioritization/SitePages/MSNA%20analysis%20(LSG-MSNi).aspx?xsdata=MDV8MDJ8fDE5ZmZkZDBlMTgyYTQ5MWUxNjUzMDhkZGNlNmVmOGYxfGQyMDBlOTAzMTliMDQ1MmViZDIxZDFhYTAxMTM5MGQ1fDB8MHw2Mzg4OTM2OTgxNzQ3NTIzMzl8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T21FM01HUmpZV0V4TURVNU5qUTVaV0ZpTXpRek1HTmpPR1F3WWpVeU1UQXhRSFJvY21WaFpDNTJNaTl0WlhOellXZGxjeTh4TnpVek56Y3pNREUyTmpjMHw5Y2NhODkyYzY5Yzc0ZmM5YWFkZjA4ZGRjZTZlZjhmMHxjODMwNzNhMzEzYWM0MGQ3ODRjNDhlODNlM2ViNTMyNQ%3D%3D&sdata=UlNiOVVRdGoxSC9QYmg4SW1Hb1ppUmlCNi8wZ2xPMGZkdG8rYzcrU2ptND0%3D&ovuser=d200e903-19b0-452e-bd21-d1aa011390d5%2Cquentin.villotta%40impact-initiatives.org&OR=Teams-HL&CT=1753776647777&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTA3MDMxODgwOSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D)
+A comprehensive **Guidance Note** is available
+[here](https://acted.sharepoint.com/sites/IMPACT-Humanitarian_Planning_Prioritization/SitePages/MSNA%20analysis%20(LSG-MSNi).aspx?xsdata=MDV8MDJ8fDE5ZmZkZDBlMTgyYTQ5MWUxNjUzMDhkZGNlNmVmOGYxfGQyMDBlOTAzMTliMDQ1MmViZDIxZDFhYTAxMTM5MGQ1fDB8MHw2Mzg4OTM2OTgxNzQ3NTIzMzl8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T21FM01HUmpZV0V4TURVNU5qUTVaV0ZpTXpRek1HTmpPR1F3WWpVeU1UQXhRSFJvY21WaFpDNTJNaTl0WlhOellXZGxjeTh4TnpVek56Y3pNREUyTmpjMHw5Y2NhODkyYzY5Yzc0ZmM5YWFkZjA4ZGRjZTZlZjhmMHxjODMwNzNhMzEzYWM0MGQ3ODRjNDhlODNlM2ViNTMyNQ%3D%3D&sdata=UlNiOVVRdGoxSC9QYmg4SW1Hb1ppUmlCNi8wZ2xPMGZkdG8rYzcrU2ptND0%3D&ovuser=d200e903-19b0-452e-bd21-d1aa011390d5%2Cquentin.villotta%40impact-initiatives.org&OR=Teams-HL&CT=1753776647777&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTA3MDMxODgwOSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D)
 for all users of the `humind` package. This document provides essential
 background on the **MSNI framework** and includes sector-specific
 guidance. Each sector includes a **“Humind Data Workflow”** section,
@@ -122,6 +122,33 @@ template when opening an issue:
 Open a **[blank
 issue](https://github.com/impact-initiatives-hppu/humind/issues/new)**
 and provide as much detail as possible.
+
+------------------------------------------------------------------------
+
+## Known Issues
+
+### GitHub Credentials Error When Installing with devtools
+
+When installing the package from GitHub using
+`devtools::install_github()`, you may encounter an error such as:
+
+    Using GitHub PAT from the git credential store.
+    Error : Failed to install 'unknown package' from GitHub:
+      HTTP error 401.
+      Bad credentials
+
+This issue is typically caused by outdated or incorrect GitHub
+credentials stored in R. For public repositories, no credentials are
+required. To resolve this, you can either update your credentials or
+delete the stored credentials using the following commands:
+
+``` r
+library(gitcreds)
+gitcreds_delete()
+```
+
+After updating or deleting the credentials, retry the installation. This
+should resolve the error for public repositories.
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -125,17 +125,22 @@ and provide as much detail as possible.
 
 ------------------------------------------------------------------------
 
-## Known Issues
+## ⚠️ Known Issues
 
 ### GitHub Credentials Error When Installing with devtools
 
 When installing the package from GitHub using
 `devtools::install_github()`, you may encounter an error such as:
 
-    Using GitHub PAT from the git credential store.
-    Error : Failed to install 'unknown package' from GitHub:
-      HTTP error 401.
-      Bad credentials
+``` r
+# install.packages("devtools")
+devtools::install_github("impact-initiatives-hppu/humind@v2025.1.1")
+
+Using GitHub PAT from the git credential store.
+Error : Failed to install 'unknown package' from GitHub:
+  HTTP error 401.
+  Bad credentials
+```
 
 This issue is typically caused by outdated or incorrect GitHub
 credentials stored in R. For public repositories, no credentials are


### PR DESCRIPTION
This pull request updates the `humind` package to improve versioning, installation guidance, and user documentation. Key changes include specifying a legacy version for a dependency, updating installation instructions, and adding troubleshooting steps for GitHub credential errors. Additionally, the documentation has been refined for clarity and accessibility.

### Dependency and versioning updates:
* Updated the `Remotes` field in `DESCRIPTION` to specify a legacy version (`impactR4PHU@v2025.1.0-legacy`).

### Installation instructions:
* Commented out the `install.packages("devtools")` line in installation examples in `README.Rmd` and `README.md` for clarity. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL40-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35)

### User documentation improvements:
* Simplified the link to the **Guidance Note** in both `README.Rmd` and `README.md` by replacing the full SharePoint URL with a cleaner "here" link. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL53-R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R50)

### Troubleshooting guidance:
* Added a new "Known Issues" section in both `README.Rmd` and `README.md` to address GitHub credential errors during installation. This includes a detailed explanation and steps to resolve the issue using the `gitcreds` package. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR105-R131) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R128-R158)