### PR TITLE
add_prot_score_practices updated handling of NA in sub dimensions

### DIFF
--- a/R/add_prot_score_practices.R
+++ b/R/add_prot_score_practices.R
@@ -162,6 +162,27 @@ add_prot_score_practices <- function(
     ) |>
     dplyr::select(-dplyr::all_of(c(".sum", ".both_na")))
 
+  na_activities <- is.na(weights_df$comp_prot_score_prot_needs_2_activities)
+  na_social <- is.na(weights_df$comp_prot_score_prot_needs_2_social)
+  na_both <- na_activities & na_social
+
+  n_act <- sum(na_activities, na.rm = TRUE)
+  n_soc <- sum(na_social, na.rm = TRUE)
+  n_both <- sum(na_both, na.rm = TRUE)
+
+  if (n_act > 0L || n_soc > 0L) {
+    cli::cli_warn(c(
+      "{.strong Missing input scores detected}",
+      "i" = "{.col comp_prot_score_prot_needs_2_activities}: {n_act} NA{cli::qty(n_act)}.",
+      "i" = "{.col comp_prot_score_prot_needs_2_social}: {n_soc} NA{cli::qty(n_soc)}.",
+      if (n_both > 0L) {
+        c(
+          "x" = "{n_both} row{?s} ha{?s/ve} both inputs NA; {.col comp_prot_score_practices} will be NA for these row{?s}."
+        )
+      }
+    ))
+  }
+
   # bind back composite and optionally weighted cols
   comp_cols <- c(
     "comp_prot_score_prot_needs_2_activities",

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -51,7 +51,7 @@ dummy_social <- generate_survey_choice_combinations(
 # Tests for the composite function
 
 test_that("adds three composite columns without weighted vars", {
-  res <- add_prot_score_practices(dummy_df)
+  res <- suppressWarnings(add_prot_score_practices(dummy_df))
 
   expect_true(all(
     c(
@@ -67,10 +67,10 @@ test_that("adds three composite columns without weighted vars", {
 
 
 test_that("includes weighted vars when .keep_weighted = TRUE", {
-  res_w <- add_prot_score_practices(
+  res_w <- suppressWarnings(add_prot_score_practices(
     dummy_df,
     .keep_weighted = TRUE
-  )
+  ))
 
   raw_cols <- c(
     str_glue("{q1}/{opts1}"),
@@ -83,10 +83,10 @@ test_that("includes weighted vars when .keep_weighted = TRUE", {
 
 
 test_that("weighted columns follow the expected 0/NA pattern", {
-  res_w <- add_prot_score_practices(
+  res_w <- suppressWarnings(add_prot_score_practices(
     dummy_df,
     .keep_weighted = TRUE
-  )
+  ))
 
   # "no" always yields 0
   expect_equal(unique(res_w[[str_glue("{q1}/no_w")]]), 0)
@@ -101,7 +101,7 @@ test_that("weighted columns follow the expected 0/NA pattern", {
 
 
 test_that("composite severity is bounded 1–4", {
-  res <- add_prot_score_practices(dummy_df)
+  res <- suppressWarnings(add_prot_score_practices(dummy_df))
 
   expect_true(all(res$comp_prot_score_practices >= 1, na.rm = TRUE))
   expect_true(all(res$comp_prot_score_practices <= 4, na.rm = TRUE))
@@ -114,13 +114,13 @@ test_that("sub-dimensions are NA when DNK or PNTA selected", {
   q1 <- "prot_needs_2_activities"
   q2 <- "prot_needs_2_social"
 
-  res <- add_prot_score_practices(
+  res <- suppressWarnings(add_prot_score_practices(
     dummy_df,
     prot_needs_2_activities = q1,
     prot_needs_2_social = q2,
     dnk = dnk,
     pnta = pnta
-  )
+  ))
 
   flagged_activities <- (dummy_df[[str_glue("{q1}/{dnk}")]] == 1 |
     dummy_df[[str_glue("{q1}/{pnta}")]] == 1)
@@ -145,13 +145,13 @@ test_that("when both sub-dimensions are NA the composite is NA but not otherwise
   q1 <- "prot_needs_2_activities"
   q2 <- "prot_needs_2_social"
 
-  res <- add_prot_score_practices(
+  res <- suppressWarnings(add_prot_score_practices(
     dummy_df,
     prot_needs_2_activities = q1,
     prot_needs_2_social = q2,
     dnk = dnk,
     pnta = pnta
-  )
+  ))
 
   flagged_activities <- (dummy_df[[str_glue("{q1}/{dnk}")]] == 1 |
     dummy_df[[str_glue("{q1}/{pnta}")]] == 1)
@@ -180,4 +180,23 @@ test_that("when both sub-dimensions are NA the composite is NA but not otherwise
       flagged_only_social
     ])
   ))
+})
+
+# test that a warning is raised either of the sub-dimensions are NA
+test_that("a warning is raised when both sub-dimensions are NA", {
+  dnk <- "dnk"
+  pnta <- "pnta"
+  q1 <- "prot_needs_2_activities"
+  q2 <- "prot_needs_2_social"
+
+  testthat::expect_warning(
+    add_prot_score_practices(
+      dummy_df,
+      prot_needs_2_activities = q1,
+      prot_needs_2_social = q2,
+      dnk = dnk,
+      pnta = pnta
+    ),
+    "Missing input scores detected"
+  )
 })

--- a/tests/testthat/test-add_prot_score_practices.R
+++ b/tests/testthat/test-add_prot_score_practices.R
@@ -138,7 +138,7 @@ test_that("sub-dimensions are NA when DNK or PNTA selected", {
 })
 
 
-# test that when na or dnk are selected, the sub dimensions are NA
+# test that when dnk or pnta are selected, the sub dimensions are NA
 test_that("when both sub-dimensions are NA the composite is NA but not otherwise", {
   dnk <- "dnk"
   pnta <- "pnta"


### PR DESCRIPTION
- Composite is NA only when both sub-dims are NA, otherwise it will take the value of whatever is available.
- Mark sub-dimensions as NA when zero + DNK/PNTA selected.
- Expand tests to cover sub-dim NA logic and composite NA behavior.

Closes #638
