### PR TITLE
test(add_loop_healthcare_needed_cat): cover NA handling w/ exhaustive loop grid

### DIFF
--- a/R/add_loop_healthcare_needed_cat.R
+++ b/R/add_loop_healthcare_needed_cat.R
@@ -109,6 +109,7 @@ add_loop_healthcare_needed_cat <- function(
   # warn if health_ind_healthcare_needed is 'yes' but health_ind_healthcare_received is NA
   healthcare_needed_received_na <- loop$health_ind_healthcare_needed == "yes" &
     is.na(loop$health_ind_healthcare_received)
+  n_flags <- sum(healthcare_needed_received_na, na.rm = TRUE)
 
   if (
     any(
@@ -116,7 +117,7 @@ add_loop_healthcare_needed_cat <- function(
     )
   ) {
     cli::cli_warn(c(
-      "x" = "{cli::qty(sum(healthcare_needed_received_na))}There {?is/are} {sum(healthcare_needed_received_na)} individual{?s} with healthcare needed as {.val yes} but healthcare received {?is/are} {.val NA}"
+      "x" = "{cli::qty(n_flags)}There {?is/are} {n_flags} individual{?s} with healthcare needed as {.val yes} but healthcare received {?is/are} {.val NA}"
     ))
   }
 

--- a/R/add_loop_healthcare_needed_cat.R
+++ b/R/add_loop_healthcare_needed_cat.R
@@ -106,6 +106,20 @@ add_loop_healthcare_needed_cat <- function(
     )
   }
 
+  # warn if health_ind_healthcare_needed is 'yes' but health_ind_healthcare_received is NA
+  healthcare_needed_received_na <- loop$health_ind_healthcare_needed == "yes" &
+    is.na(loop$health_ind_healthcare_received)
+
+  if (
+    any(
+      healthcare_needed_received_na
+    )
+  ) {
+    cli::cli_warn(c(
+      "x" = "{cli::qty(sum(healthcare_needed_received_na))}There {?is/are} {sum(healthcare_needed_received_na)} individual{?s} with healthcare needed as {.val yes} but healthcare received {?is/are} {.val NA}"
+    ))
+  }
+
   #------ Compute
 
   # Calculate dummy variables

--- a/R/add_loop_healthcare_needed_cat.R
+++ b/R/add_loop_healthcare_needed_cat.R
@@ -167,17 +167,17 @@ add_loop_healthcare_needed_cat <- function(
       health_ind_healthcare_needed_cat %in%
         c("yes_met_need", "yes_unmet_need") ~
         0,
-      .default = 0
+      .default = NA_real_
     ),
     health_ind_healthcare_needed_yes_unmet = dplyr::case_when(
       health_ind_healthcare_needed_cat == "yes_unmet_need" ~ 1,
       health_ind_healthcare_needed_cat %in% c("no_need", "yes_met_need") ~ 0,
-      .default = 0
+      .default = NA_real_
     ),
     health_ind_healthcare_needed_yes_met = dplyr::case_when(
       health_ind_healthcare_needed_cat == "yes_met_need" ~ 1,
       health_ind_healthcare_needed_cat %in% c("no_need", "yes_unmet_need") ~ 0,
-      .default = 0
+      .default = NA_real_
     )
   )
 

--- a/tests/testthat/test-add_loop_healthcare_needed_cat.R
+++ b/tests/testthat/test-add_loop_healthcare_needed_cat.R
@@ -1,4 +1,4 @@
-# # Sample data for testing
+# Sample data for testing
 loop <- data.frame(
   uuid = c(1, 2, 3, 4, 5, 6),
   health_ind_healthcare_needed = c("yes", "no", "dnk", "pnta", "yes", "no"),

--- a/tests/testthat/test-add_loop_healthcare_needed_cat.R
+++ b/tests/testthat/test-add_loop_healthcare_needed_cat.R
@@ -139,3 +139,15 @@ test_that("healthcare received NA causes healthcare needed cat to be NA when hea
   )
   expect_true(all(is.na(result$health_ind_healthcare_needed_cat)))
 })
+
+
+test_that("dummy variables are NA when healthcare_received is NA", {
+  result <- suppressWarnings(add_loop_healthcare_needed_cat(exhaustive_loop))
+  flagged <- result$health_ind_healthcare_needed_d == 1 &
+    is.na(result$health_ind_healthcare_received_d)
+  flagged_rows <- result[flagged, ]
+
+  expect_true(all(is.na(flagged_rows$health_ind_healthcare_needed_yes_unmet)))
+
+  expect_true(all(is.na(flagged_rows$health_ind_healthcare_needed_yes_met)))
+})

--- a/tests/testthat/test-add_loop_healthcare_needed_cat.R
+++ b/tests/testthat/test-add_loop_healthcare_needed_cat.R
@@ -1,4 +1,4 @@
-# Sample data for testing
+# # Sample data for testing
 loop <- data.frame(
   uuid = c(1, 2, 3, 4, 5, 6),
   health_ind_healthcare_needed = c("yes", "no", "dnk", "pnta", "yes", "no"),
@@ -6,6 +6,7 @@ loop <- data.frame(
   ind_age = c(25, 30, 2, 8, 12, 40),
   stringsAsFactors = FALSE
 )
+
 
 main <- data.frame(
   uuid = c(1, 2, 3, 4, 5, 6),
@@ -116,4 +117,22 @@ test_that("it works if UUID columns are named X_UUID in main, and X_SUB_UUID in 
     result$health_ind_healthcare_needed_yes_met_n,
     c(0, 0, 0, 0, 1, 0)
   )
+})
+
+exhaustive_loop <- tidyr::expand_grid(
+  health_ind_healthcare_needed = c("yes", "no", "dnk", "pnta", NA),
+  health_ind_healthcare_received = c("yes", "no", "dnk", "pnta", NA),
+  ind_age = 2:80
+) |>
+  mutate(uuid = row_number())
+
+
+test_that("healthcare received NA causes healthcare needed cat to be NA when healthcare needed is yes", {
+  test_data <- exhaustive_loop |>
+    filter(
+      health_ind_healthcare_needed == "yes",
+      is.na(health_ind_healthcare_received)
+    )
+  result <- add_loop_healthcare_needed_cat(test_data)
+  expect_true(all(is.na(result$health_ind_healthcare_needed_cat)))
 })

--- a/tests/testthat/test-add_loop_healthcare_needed_cat.R
+++ b/tests/testthat/test-add_loop_healthcare_needed_cat.R
@@ -129,10 +129,13 @@ exhaustive_loop <- tidyr::expand_grid(
 
 test_that("healthcare received NA causes healthcare needed cat to be NA when healthcare needed is yes", {
   test_data <- exhaustive_loop |>
-    filter(
+    dplyr::filter(
       health_ind_healthcare_needed == "yes",
       is.na(health_ind_healthcare_received)
     )
-  result <- add_loop_healthcare_needed_cat(test_data)
+  result <- expect_warning(
+    add_loop_healthcare_needed_cat(test_data),
+    "healthcare needed.+but healthcare received.+"
+  )
   expect_true(all(is.na(result$health_ind_healthcare_needed_cat)))
 })


### PR DESCRIPTION
Build exhaustive_loop via tidyr::expand_grid (needed/received ∈
{yes,no,dnk,pnta,NA}, ind_age 2:80) and assign uuid with row_number().

Add test: when health_ind_healthcare_needed == "yes" and
health_ind_healthcare_received is NA, health_ind_healthcare_needed_cat
must be NA (no implicit classification).

This strengthens edge-case coverage for add_loop_healthcare_needed_cat
and makes NA semantics explicit.

It will warn when when health_ind_healthcare_needed == "yes" and health_ind_healthcare_received is NA
<img width="1020" height="37" alt="image" src="https://github.com/user-attachments/assets/9dec8b50-e415-4af5-8aef-775d538486a4" />

Closes #636
