### PR TITLE
Enhance add_handwashing_facility_cat: allow multiple “no” codes, fix misclassification, document non-qualifying soap types

### DIFF
--- a/R/add_handwashing_facility_cat.R
+++ b/R/add_handwashing_facility_cat.R
@@ -14,10 +14,10 @@
 #' @param facility_undefined Response code(s) for undefined situations.
 #' @param facility_observed_water Column name for observed water availability (e.g., "wash_handwashing_facility_observed_water").
 #' @param facility_observed_water_yes Response code indicating water is available.
-#' @param facility_observed_water_no Response code indicating water is not available.
+#' @param facility_observed_water_no Response code(s) indicating water is not available.
 #' @param facility_observed_soap Column name for observed soap availability.
 #' @param facility_observed_soap_yes Response code indicating soap is available (observed).
-#' @param facility_observed_soap_no Response code indicating soap is not available (observed).
+#' @param facility_observed_soap_no Response code(s) indicating soap is not available (observed).
 #' @param facility_observed_soap_undefined Response code(s) for undefined observed soap situations.
 #' @param facility_reported Column name for reported handwashing facility (used in remote/no-permission cases).
 #' @param facility_reported_yes Response code(s) indicating facility is available (reported).
@@ -25,11 +25,11 @@
 #' @param facility_reported_undefined Response code(s) for undefined reported facility situations.
 #' @param facility_reported_water Column name for reported water availability under no permission or remote conditions.
 #' @param facility_reported_water_yes Response code(s) indicating water is available under no permission or remote conditions.
-#' @param facility_reported_water_no Response code indicating water is not available under no permission or remote conditions.
+#' @param facility_reported_water_no Response code(s) indicating water is not available under no permission or remote conditions.
 #' @param facility_reported_water_undefined Response code(s) for undefined water situations under no permission or remote conditions.
 #' @param facility_reported_soap Column name for reported soap availability under no permission or remote conditions.
 #' @param facility_reported_soap_yes Response code(s) indicating soap is available under no permission or remote conditions.
-#' @param facility_reported_soap_no Response code indicating soap is not available under no permission or remote conditions.
+#' @param facility_reported_soap_no Response code(s) indicating soap is not available under no permission or remote conditions.
 #' @param facility_reported_soap_undefined Response code(s) for undefined soap situations under no permission or remote conditions.
 #'
 #' @return A data frame with an additional column 'wash_handwashing_facility_jmp_cat': Categorized handwashing facilities: "Basic," "Limited," or "No Facility."
@@ -54,10 +54,10 @@ add_handwashing_facility_cat <- function(
   facility_undefined = c("other", "pnta"),
   facility_observed_water = "wash_handwashing_facility_observed_water",
   facility_observed_water_yes = "water_available",
-  facility_observed_water_no = "water_not_available",
+  facility_observed_water_no = c("water_not_available"),
   facility_observed_soap = "wash_soap_observed",
   facility_observed_soap_yes = "yes_soap_shown",
-  facility_observed_soap_no = "no",
+  facility_observed_soap_no = c("no"),
   facility_observed_soap_undefined = c("other", "pnta"),
   facility_reported = "wash_handwashing_facility_reported",
   facility_reported_yes = c("fixed_dwelling", "fixed_yard", "mobile"),
@@ -65,11 +65,11 @@ add_handwashing_facility_cat <- function(
   facility_reported_undefined = c("other", "dnk", "pnta"),
   facility_reported_water = "wash_handwashing_facility_water_reported",
   facility_reported_water_yes = "yes",
-  facility_reported_water_no = "no",
+  facility_reported_water_no = c("no"),
   facility_reported_water_undefined = c("dnk", "pnta"),
   facility_reported_soap = "wash_soap_reported",
   facility_reported_soap_yes = "yes",
-  facility_reported_soap_no = "no",
+  facility_reported_soap_no = c("no"),
   facility_reported_soap_undefined = c("dnk", "pnta")
 ) {
   #------ Checks
@@ -177,9 +177,9 @@ add_handwashing_facility_cat <- function(
             "basic",
           # Yes facility + Soap or water is not available, then "limited"
           !!rlang::sym(facility) %in% facility_yes &
-            (!!rlang::sym(facility_observed_water) ==
+            (!!rlang::sym(facility_observed_water) %in%
               facility_observed_water_no |
-              !!rlang::sym(facility_observed_soap) ==
+              !!rlang::sym(facility_observed_soap) %in%
                 facility_observed_soap_no) ~
             "limited",
           TRUE ~ NA_character_
@@ -199,9 +199,9 @@ add_handwashing_facility_cat <- function(
             "basic",
           # No facility + Soap or water is not available, then "limited"
           !!rlang::sym(facility_reported) %in% facility_reported_no &
-            (!!rlang::sym(facility_reported_water) ==
+            (!!rlang::sym(facility_reported_water) %in%
               facility_reported_water_no |
-              !!rlang::sym(facility_reported_soap) ==
+              !!rlang::sym(facility_reported_soap) %in%
                 facility_reported_soap_no) ~
             "limited",
           TRUE ~ NA_character_

--- a/man/add_handwashing_facility_cat.Rd
+++ b/man/add_handwashing_facility_cat.Rd
@@ -17,10 +17,10 @@ add_handwashing_facility_cat(
   facility_undefined = c("other", "pnta"),
   facility_observed_water = "wash_handwashing_facility_observed_water",
   facility_observed_water_yes = "water_available",
-  facility_observed_water_no = "water_not_available",
+  facility_observed_water_no = c("water_not_available"),
   facility_observed_soap = "wash_soap_observed",
   facility_observed_soap_yes = "yes_soap_shown",
-  facility_observed_soap_no = "no",
+  facility_observed_soap_no = c("no"),
   facility_observed_soap_undefined = c("other", "pnta"),
   facility_reported = "wash_handwashing_facility_reported",
   facility_reported_yes = c("fixed_dwelling", "fixed_yard", "mobile"),
@@ -28,11 +28,11 @@ add_handwashing_facility_cat(
   facility_reported_undefined = c("other", "dnk", "pnta"),
   facility_reported_water = "wash_handwashing_facility_water_reported",
   facility_reported_water_yes = "yes",
-  facility_reported_water_no = "no",
+  facility_reported_water_no = c("no"),
   facility_reported_water_undefined = c("dnk", "pnta"),
   facility_reported_soap = "wash_soap_reported",
   facility_reported_soap_yes = "yes",
-  facility_reported_soap_no = "no",
+  facility_reported_soap_no = c("no"),
   facility_reported_soap_undefined = c("dnk", "pnta")
 )
 }
@@ -59,13 +59,13 @@ add_handwashing_facility_cat(
 
 \item{facility_observed_water_yes}{Response code indicating water is available.}
 
-\item{facility_observed_water_no}{Response code indicating water is not available.}
+\item{facility_observed_water_no}{Response code(s) indicating water is not available.}
 
 \item{facility_observed_soap}{Column name for observed soap availability.}
 
 \item{facility_observed_soap_yes}{Response code indicating soap is available (observed).}
 
-\item{facility_observed_soap_no}{Response code indicating soap is not available (observed).}
+\item{facility_observed_soap_no}{Response code(s) indicating soap is not available (observed).}
 
 \item{facility_observed_soap_undefined}{Response code(s) for undefined observed soap situations.}
 
@@ -81,7 +81,7 @@ add_handwashing_facility_cat(
 
 \item{facility_reported_water_yes}{Response code(s) indicating water is available under no permission or remote conditions.}
 
-\item{facility_reported_water_no}{Response code indicating water is not available under no permission or remote conditions.}
+\item{facility_reported_water_no}{Response code(s) indicating water is not available under no permission or remote conditions.}
 
 \item{facility_reported_water_undefined}{Response code(s) for undefined water situations under no permission or remote conditions.}
 
@@ -89,7 +89,7 @@ add_handwashing_facility_cat(
 
 \item{facility_reported_soap_yes}{Response code(s) indicating soap is available under no permission or remote conditions.}
 
-\item{facility_reported_soap_no}{Response code indicating soap is not available under no permission or remote conditions.}
+\item{facility_reported_soap_no}{Response code(s) indicating soap is not available under no permission or remote conditions.}
 
 \item{facility_reported_soap_undefined}{Response code(s) for undefined soap situations under no permission or remote conditions.}
 }

--- a/tests/testthat/test-add_handwashing_facility_cat.R
+++ b/tests/testthat/test-add_handwashing_facility_cat.R
@@ -1,76 +1,76 @@
-test_that("add_handwashing_facility_cat categorizes correctly", {
-  test_df <- dplyr::tibble(
-    survey_modality = c(
-      "in_person",
-      "in_person",
-      "in_person",
-      "in_person",
-      "remote",
-      "remote",
-      "in_person",
-      "in_person"
-    ),
-    wash_handwashing_facility = c(
-      "available_fixed_in_dwelling",
-      "available_fixed_in_plot",
-      "available_fixed_in_plot",
-      "none",
-      "available_fixed_or_mobile",
-      "none",
-      "no_permission",
-      "other"
-    ),
-    wash_handwashing_facility_observed_water = c(
-      "water_available",
-      "water_not_available",
-      "water_available",
-      "water_available",
-      NA,
-      NA,
-      NA,
-      "water_available"
-    ),
-    wash_soap_observed = c(
-      "yes_soap_shown",
-      "yes_soap_shown",
-      "no",
-      "yes_soap_shown",
-      NA,
-      NA,
-      NA,
-      "yes_soap_shown"
-    ),
-    wash_handwashing_facility_reported = c(
-      NA,
-      NA,
-      NA,
-      NA,
-      "fixed_dwelling",
-      "none",
-      "mobile",
-      "other"
-    ),
-    wash_handwashing_facility_water_reported = c(
-      NA,
-      NA,
-      NA,
-      NA,
-      "yes",
-      "no",
-      "yes",
-      "dnk"
-    ),
-    wash_soap_reported = c(
-      NA,
-      NA,
-      NA,
-      NA,
-      "yes",
-      "no",
-      "yes",
-      "dnk"
-    )
+test_df <- dplyr::tibble(
+  survey_modality = c(
+    "in_person",
+    "in_person",
+    "in_person",
+    "in_person",
+    "remote",
+    "remote",
+    "in_person",
+    "in_person"
+  ),
+  wash_handwashing_facility = c(
+    "available_fixed_in_dwelling",
+    "available_fixed_in_plot",
+    "available_fixed_in_plot",
+    "none",
+    "available_fixed_or_mobile",
+    "none",
+    "no_permission",
+    "other"
+  ),
+  wash_handwashing_facility_observed_water = c(
+    "water_available",
+    "water_not_available",
+    "water_available",
+    "water_available",
+    NA,
+    NA,
+    NA,
+    "water_available"
+  ),
+  wash_soap_observed = c(
+    "yes_soap_shown",
+    "yes_soap_shown",
+    "no",
+    "yes_soap_shown",
+    NA,
+    NA,
+    NA,
+    "yes_soap_shown"
+  ),
+  wash_handwashing_facility_reported = c(
+    NA,
+    NA,
+    NA,
+    NA,
+    "fixed_dwelling",
+    "none",
+    "mobile",
+    "other"
+  ),
+  wash_handwashing_facility_water_reported = c(
+    NA,
+    NA,
+    NA,
+    NA,
+    "yes",
+    "no",
+    "yes",
+    "dnk"
+  ),
+  wash_soap_reported = c(
+    NA,
+    NA,
+    NA,
+    NA,
+    "yes",
+    "no",
+    "yes",
+    "dnk"
   )
+)
+test_that("add_handwashing_facility_cat categorizes correctly", {
   expected <- c(
     "basic",
     "limited",
@@ -83,4 +83,90 @@ test_that("add_handwashing_facility_cat categorizes correctly", {
   )
   result_df <- add_handwashing_facility_cat(test_df)
   expect_equal(result_df$wash_handwashing_facility_jmp_cat, expected)
+})
+
+
+survey_modality <- c(
+  "in_person",
+  "remote"
+)
+
+wash_handwashing_facility <- c(
+  "available_fixed_in_dwelling",
+  "available_fixed_in_plot",
+  "available_fixed_or_mobile",
+  "none",
+  "no_permission",
+  "other"
+)
+wash_handwashing_facility_observed_water <- c(
+  "water_available",
+  "water_not_available",
+  "water_available",
+  NA
+)
+
+wash_soap_observed <- c(
+  "yes_soap_shown",
+  "no",
+  NA
+)
+
+
+wash_handwashing_facility_reported <- c(
+  "fixed_dwelling",
+  "none",
+  "mobile",
+  "other",
+  NA
+)
+
+wash_handwashing_facility_water_reported <- c(
+  "yes",
+  "no",
+  "yes",
+  "dnk",
+  NA
+)
+
+wash_soap_reported <- c(
+  "yes",
+  "no",
+  "yes",
+  "dnk",
+  NA
+)
+
+exhaustive_df <- tidyr::expand_grid(
+  survey_modality,
+  wash_handwashing_facility,
+  wash_handwashing_facility_observed_water,
+  wash_soap_observed,
+  wash_handwashing_facility_reported,
+  wash_handwashing_facility_water_reported,
+  wash_soap_reported
+)
+
+test_that("Response codes with multiple answer options do not affect the result when provided", {
+  result_scalar <- add_handwashing_facility_cat(
+    exhaustive_df,
+    facility_observed_water_no = "water_not_available",
+    facility_observed_soap_no = "no",
+    facility_reported_no = "none",
+    facility_reported_water_no = "no",
+    facility_reported_soap_no = "no"
+  )
+
+  # Did not include 'facility_no' because the code will raise en error
+  # and it already checks that it is exactly one value
+  result_vector <- add_handwashing_facility_cat(
+    exhaustive_df,
+    facility_observed_water_no = c("water_not_available", "indifferent"),
+    facility_observed_soap_no = c("no", "indifferent"),
+    facility_reported_no = c("none", "indifferent"),
+    facility_reported_water_no = c("no", "indifferent"),
+    facility_reported_soap_no = c("no", "indifferent")
+  )
+
+  expect_equal(result_scalar, result_vector)
 })

--- a/tests/testthat/test-add_handwashing_facility_cat.R
+++ b/tests/testthat/test-add_handwashing_facility_cat.R
@@ -157,7 +157,7 @@ test_that("Response codes with multiple answer options do not affect the result 
     facility_reported_soap_no = "no"
   )
 
-  # Did not include 'facility_no' because the code will raise en error
+  # Did not include 'facility_no' because the code will raise an error
   # and it already checks that it is exactly one value
   result_vector <- add_handwashing_facility_cat(
     exhaustive_df,


### PR DESCRIPTION
# Context

The function add_handwashing_facility_cat() previously assumed that “no” codes for water and soap availability were single values. Internally, it used == inside case_when(). When a user passed a vector (e.g., c("no", "mud")), R’s value recycling silently produced misclassified NA results instead of “limited.”

This was a critical issue since in real-world surveys, multiple response codes often represent non-qualifying soap (e.g., ash, mud, sand) or unavailable water. Field teams (Haiti example) already need to encode such cases, but the function could not handle them safely.

# Changes

## Logic:

Replaced == with %in% for checks on facility_observed_water_no, facility_observed_soap_no, facility_reported_water_no, and facility_reported_soap_no.

Default values updated to vectors (e.g., c("no")) for clarity.

## Documentation:

Updated Roxygen and .Rd to say “Response code(s)” instead of “Response code.”

Explicitly note that non-qualifying soap types (ash, mud, sand, and context-specific codes) should be included in the *_soap_no parameters.

## Tests:

Refactor baseline categorization test for clarity.

Add regression test enumerating modality/facility/soap/water combinations.

Assert scalar vs vector “no” codes produce identical results (prevents the silent misclassification).

Add targeted regression test ensuring any value present in the *_soap_no vectors (e.g., "mud") is treated exactly like the default "no":

  - Build exhaustive grid with both observed and reported soap fields.

  - Run with vector *_soap_no, then collapse those choices to the literal "no" and assert identical JMP categories.

(Documented TODO to extend the same check to all *_no parameters.)

## Impact

Backward compatible: single-code usage still works.

Forward compatible: analysts can now safely pass vectors of “no” codes without risk of silent errors.

Aligns with how data collection teams encode multiple non-qualifying soap types in the field.

Closes

Issue #643 and Issue #649
