### PR TITLE
fix(practices, rights): Handle different column separators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # humind (development version)
 
+# humind 2025.1.3
+
+## 🛠 Codebase Changes
+
+### 🛠 Bug Fixes
+
+* Protection: respect the `sep` argument when constructing choice-column names in `add_prot_score_practices()` and `add_prot_score_rights()`. Both `/` (default) and `.` separators are supported. Tests updated; no breaking changes.
+
 # humind 2025.1.2
 
 This release introduces major terminology and logic changes across the MSNI framework, WASH, Protection, and Healthcare indicators. Several functions have new required parameters, altered defaults, or renamed outputs — **breaking changes are significant**.


### PR DESCRIPTION
Handle column separators  (“/” or “.”)

The functions previously assumed “/” when constructing choice-column names, causing lookups to fail on dot-separated datasets. We now respect the `sep` argument in all lookups, so both separators are supported.

Changes
- Replace hard-coded “/” with `{sep}` in glue-based column access:
  - R/add_prot_score_practices.R
  - R/add_prot_score_rights.R
- Tests:
  - Ensure dot-separated inputs work when `sep = "."`
  - Assert an error when `sep` does not match the data (guardrail)

Impact
- Restores expected behavior for datasets using either “/” (default) or “.”.
- No change for slash-separated inputs.

Closes #652