### PR TITLE
fix(shelter): reclassify tent from adequate to inadequate shelter type

### DIFF
--- a/R/add_shelter_type_cat.R
+++ b/R/add_shelter_type_cat.R
@@ -24,8 +24,8 @@ add_shelter_type_cat <- function(
   sl_collective_center = "collective_center",
   sl_undefined = "pnta",
   shelter_type_individual = "snfi_shelter_type_individual",
-  adequate = c("house", "apartment", "tent"),
-  inadequate = c("makeshift", "unfinished_building"),
+  adequate = c("house", "apartment"),
+  inadequate = c("makeshift", "unfinished_building", "tent"),
   undefined = c("pnta", "other", "dnk")
 ) {
   #------ Checks

--- a/tests/testthat/test-add_shelter_type_cat.R
+++ b/tests/testthat/test-add_shelter_type_cat.R
@@ -71,7 +71,7 @@ test_that("add_shelter_type_cat handles adequate and inadequate shelter types", 
     snfi_shelter_type_cat = c(
       "adequate",
       "adequate",
-      "adequate",
+      "inadequate",
       "inadequate",
       "inadequate"
     )
@@ -112,4 +112,48 @@ test_that("add_shelter_type_cat handles invalid values", {
   )
 
   expect_error(add_shelter_type_cat(df), class = "error")
+})
+
+test_that("add_shelter_type_cat classifies tent as inadequate", {
+  # Test that tent is classified as inadequate when shelter_type_individual is evaluated
+  df <- data.frame(
+    snfi_shelter_type = c(
+      "individual_shelter",
+      "other",
+      "something_else"
+    ),
+    snfi_shelter_type_individual = c("tent", "tent", "tent")
+  )
+
+  result <- add_shelter_type_cat(df)
+
+  expected <- data.frame(
+    snfi_shelter_type = c(
+      "individual_shelter",
+      "other",
+      "something_else"
+    ),
+    snfi_shelter_type_individual = c("tent", "tent", "tent"),
+    snfi_shelter_type_cat = c("inadequate", "inadequate", "inadequate")
+  )
+
+  expect_equal(result, expected)
+})
+
+test_that("add_shelter_type_cat handles tent with priority shelter types", {
+  # Test that primary shelter_type takes priority over tent in shelter_type_individual
+  df <- data.frame(
+    snfi_shelter_type = c("none", "collective_center", "pnta"),
+    snfi_shelter_type_individual = c("tent", "tent", "tent")
+  )
+
+  result <- add_shelter_type_cat(df)
+
+  expected <- data.frame(
+    snfi_shelter_type = c("none", "collective_center", "pnta"),
+    snfi_shelter_type_individual = c("tent", "tent", "tent"),
+    snfi_shelter_type_cat = c("none", "inadequate", "undefined")
+  )
+
+  expect_equal(result, expected)
 })


### PR DESCRIPTION
## Summary
- Reclassifies "tent" from adequate to inadequate shelter type in `add_shelter_type_cat()` function
- Adds comprehensive test coverage to ensure tent is correctly categorized as inadequate shelter across different scenarios

## Changes
- **R/add_shelter_type_cat.R**: Moved "tent" from the `adequate` category to the `inadequate` category in the default parameters
- **tests/testthat/test-add_shelter_type_cat.R**: 
  - Updated existing test expectation to reflect tent as inadequate
  - Added new test case to verify tent classification when `shelter_type_individual` is evaluated
  - Added test case to verify that primary `shelter_type` values (none, collective_center, pnta) maintain priority over tent in `shelter_type_individual`

## Rationale
Tents do not provide adequate shelter and should be classified as inadequate housing, aligning with humanitarian shelter standards.

Closes #656