### PR TITLE
feat(internals): add is data.frame `is_df()` checker/validator and add it to `if_not_in_stop()`

### DIFF
--- a/R/internals.R
+++ b/R/internals.R
@@ -159,10 +159,10 @@ subvec_not_in <- function(vector, set) {
 #'
 #' @return A stop statement
 if_not_in_stop <- function(df, cols, df_name, arg = NULL) {
-  missing_cols <- subvec_not_in(cols, colnames(df))
-
   # check that df is a data frame
   is_df(df, df_name)
+
+  missing_cols <- subvec_not_in(cols, colnames(df))
 
   # prepare message
   if (is.null(arg)) {
@@ -211,7 +211,7 @@ is_df <- function(df, arg = NULL) {
     cli::cli_abort(
       c(
         "Input {arg} must be a data.frame.",
-        "i" = glue::glue("Input is of class: {class(df)}.")
+        "i" = "Input is of class: {class(df)}."
       )
     )
   }

--- a/R/internals.R
+++ b/R/internals.R
@@ -161,6 +161,10 @@ subvec_not_in <- function(vector, set) {
 if_not_in_stop <- function(df, cols, df_name, arg = NULL) {
   missing_cols <- subvec_not_in(cols, colnames(df))
 
+  # check that df is a data frame
+  is_df(df, df_name)
+
+  # prepare message
   if (is.null(arg)) {
     if (length(missing_cols) >= 2) {
       msg <- glue::glue("The following columns are missing in `{df_name}`: ")
@@ -193,4 +197,23 @@ if_not_in_stop <- function(df, cols, df_name, arg = NULL) {
       )
     )
   }
+}
+
+
+#' @title Stop statement "If input is not a data.frame"
+#'
+#' @param df A data frame
+#' @param arg Default to NULL.
+#'
+#' @return A stop statement
+is_df <- function(df, arg = NULL) {
+  if (!is.data.frame(df)) {
+    cli::cli_abort(
+      c(
+        "Input {arg} must be a data.frame.",
+        "i" = glue::glue("Input is of class: {class(df)}.")
+      )
+    )
+  }
+  invisible(TRUE)
 }

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -171,13 +171,13 @@ test_that("if_not_in_stop stops when input is not a data.frame", {
 
 test_that("is_df handles non-data.frame input", {
   expect_error(
-    humind:::is_df("not_a_df", "test_arg"),
+    is_df("not_a_df", "test_arg"),
     class = "error",
     regexp = "Input test_arg must be a data.frame."
   )
 })
 
 test_that("is_df works with data.frame input", {
-  expect_true(humind:::is_df(df, "test_arg"))
-  expect_silent(humind:::is_df(df, "test_arg"))
+  expect_true(is_df(df, "test_arg"))
+  expect_silent(is_df(df, "test_arg"))
 })

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -22,6 +22,11 @@ df_non_numeric <- data.frame(
   col2 = c(1, 2, 3)
 )
 
+
+########################
+### are_cols_numeric
+########################
+
 test_that("are_cols_numeric works with default parameters", {
   expect_true(humind:::are_cols_numeric(df, c("col1", "col3", "col4")))
 })
@@ -44,6 +49,10 @@ test_that("are_cols_numeric handles all NA columns", {
   expect_error(humind:::are_cols_numeric(df_all_na, c("col1")), class = "error")
 })
 
+##########################
+### are_values_in_range
+##########################
+
 test_that("are_values_in_range works with default parameters", {
   expect_true(humind:::are_values_in_range(df, c("col1", "col3", "col4")))
 })
@@ -63,6 +72,10 @@ test_that("are_values_in_range handles missing columns", {
     class = "error"
   )
 })
+
+#############################
+### are_values_in_set
+#############################
 
 test_that("are_values_in_set works with default parameters", {
   expect_true(humind:::are_values_in_set(
@@ -104,6 +117,10 @@ test_that("are_values_in_set handles all NA columns", {
   ))
 })
 
+##############################
+## subvec_in and subvec_not_in
+##############################
+
 test_that("subvec_in works correctly", {
   expect_equal(humind:::subvec_in(c(1, 2, 3), c(2, 3)), c(2, 3))
 })
@@ -111,6 +128,10 @@ test_that("subvec_in works correctly", {
 test_that("subvec_not_in works correctly", {
   expect_equal(humind:::subvec_not_in(c(1, 2, 3), c(2, 3)), 1)
 })
+
+################################
+### if_not_in_stop
+################################
 
 test_that("if_not_in_stop handles missing columns correctly", {
   expect_error(
@@ -128,4 +149,35 @@ test_that("if_not_in_stop works with custom argument", {
     humind:::if_not_in_stop(df, c("col1", "col6"), "df", arg = "test_arg"),
     class = "error"
   )
+})
+
+test_that("if_not_in_stop stops when input is not a data.frame", {
+  expect_error(
+    humind:::if_not_in_stop(
+      "not_a_df",
+      c("col1", "col6"),
+      "df",
+      df_name = "test_arg"
+    ),
+    class = "error",
+    regexp = "test_arg must be a data.frame"
+  )
+})
+
+
+########################
+### is_df
+########################
+
+test_that("is_df handles non-data.frame input", {
+  expect_error(
+    humind:::is_df("not_a_df", "test_arg"),
+    class = "error",
+    regexp = "Input test_arg must be a data.frame."
+  )
+})
+
+test_that("is_df works with data.frame input", {
+  expect_true(humind:::is_df(df, "test_arg"))
+  expect_silent(humind:::is_df(df, "test_arg"))
 })


### PR DESCRIPTION
To be checked but now checking for main input being a data.frame should cover almost all functions, basically any function that uses internally if_not_in_stop or other internals based on if_not_in_stop such as are_cols_numeric.