### PR TITLE
feat(cm): IND162 catastrophic health spending + IND097 water share of income

### DIFF
--- a/R/add_expenditure_healthcare_share_income.R
+++ b/R/add_expenditure_healthcare_share_income.R
@@ -10,9 +10,9 @@
 #' households with catastrophic health care spending.
 #'
 #' This is a convenience wrapper around `add_expenditure_type_share_income()`
-#' with defaults set for the health expenditure module. The healthcare
-#' expenditure question has a 6-month (180-day) recall period while income is
-#' collected over 30 days, so the default `expenditure_recall_period` is 180.
+#' with fixed parameters for the health expenditure module: expenditure recall
+#' period is 180 days (6 months), income recall period is 30 days, and the
+#' catastrophic threshold is 0.25 (25%).
 #'
 #' Prerequisite: run `add_expenditure_type_zero_infreq()` before calling this
 #' function. `cm_income_total` must also be present in `df`, either directly
@@ -21,35 +21,26 @@
 #' @param df A data frame.
 #' @param expenditure_type Column name for infrequent health expenditure amount.
 #' @param total_income Column name for total household income.
-#' @param expenditure_recall_period Recall period of the health expenditure
-#'   column in days. Default: `180` (6 months).
-#' @param income_recall_period Recall period of the income column in days.
-#'   Default: `30`.
-#' @param catastrophic_threshold Numeric threshold for catastrophic spending
-#'   (proportion). Default: `0.10` (10%).
 #'
 #' @return A data frame with two additional columns:
 #'
 #' * `cm_expenditure_infrequent_health_share_income`: Recall-normalised health
 #'   expenditure share of income, or `NA` if income is 0 or `NA`.
 #' * `cm_expenditure_infrequent_health_share_income_d`: `1L` if catastrophic
-#'   (share >= threshold), `0L` otherwise, `NA` if share is `NA`.
+#'   (share >= 0.25), `0L` otherwise, `NA` if share is `NA`.
 #'
 #' @export
 add_expenditure_healthcare_share_income <- function(
   df,
   expenditure_type = "cm_expenditure_infrequent_health",
-  total_income = "cm_income_total",
-  expenditure_recall_period = 180,
-  income_recall_period = 30,
-  catastrophic_threshold = 0.10
+  total_income = "cm_income_total"
 ) {
   add_expenditure_type_share_income(
     df,
     expenditure_type = expenditure_type,
     income_total = total_income,
-    expenditure_recall_period = expenditure_recall_period,
-    income_recall_period = income_recall_period,
-    catastrophic_threshold = catastrophic_threshold
+    expenditure_recall_period = 180,
+    income_recall_period = 30,
+    catastrophic_threshold = 0.25
   )
 }

--- a/R/add_expenditure_healthcare_share_income.R
+++ b/R/add_expenditure_healthcare_share_income.R
@@ -1,0 +1,55 @@
+# ANA
+# 2025 Indicator ID: IND162
+# 2025 Metric ID: TBD
+
+#' @title Add Healthcare Expenditure Share of Income
+#'
+#' @description
+#' Calculates the share of infrequent healthcare expenditure relative to total
+#' household income, normalising both to the same recall period, and flags
+#' households with catastrophic health care spending.
+#'
+#' This is a convenience wrapper around `add_expenditure_type_share_income()`
+#' with defaults set for the health expenditure module. The healthcare
+#' expenditure question has a 6-month (180-day) recall period while income is
+#' collected over 30 days, so the default `expenditure_recall_period` is 180.
+#'
+#' Prerequisite: run `add_expenditure_type_zero_infreq()` before calling this
+#' function. `cm_income_total` must also be present in `df`, either directly
+#' from the survey or via `add_income_source_prop()`.
+#'
+#' @param df A data frame.
+#' @param expenditure_type Column name for infrequent health expenditure amount.
+#' @param total_income Column name for total household income.
+#' @param expenditure_recall_period Recall period of the health expenditure
+#'   column in days. Default: `180` (6 months).
+#' @param income_recall_period Recall period of the income column in days.
+#'   Default: `30`.
+#' @param catastrophic_threshold Numeric threshold for catastrophic spending
+#'   (proportion). Default: `0.10` (10%).
+#'
+#' @return A data frame with two additional columns:
+#'
+#' * `cm_expenditure_infrequent_health_share_income`: Recall-normalised health
+#'   expenditure share of income, or `NA` if income is 0 or `NA`.
+#' * `cm_expenditure_infrequent_health_share_income_d`: `1L` if catastrophic
+#'   (share >= threshold), `0L` otherwise, `NA` if share is `NA`.
+#'
+#' @export
+add_expenditure_healthcare_share_income <- function(
+  df,
+  expenditure_type = "cm_expenditure_infrequent_health",
+  total_income = "cm_income_total",
+  expenditure_recall_period = 180,
+  income_recall_period = 30,
+  catastrophic_threshold = 0.10
+) {
+  add_expenditure_type_share_income(
+    df,
+    expenditure_type = expenditure_type,
+    income_total = total_income,
+    expenditure_recall_period = expenditure_recall_period,
+    income_recall_period = income_recall_period,
+    catastrophic_threshold = catastrophic_threshold
+  )
+}

--- a/R/add_expenditure_healthcare_share_income.R
+++ b/R/add_expenditure_healthcare_share_income.R
@@ -29,6 +29,7 @@
 #' * `cm_expenditure_infrequent_health_share_income_d`: `1L` if catastrophic
 #'   (share >= 0.25), `0L` otherwise, `NA` if share is `NA`.
 #'
+#' @family expenditure_share_income
 #' @export
 add_expenditure_healthcare_share_income <- function(
   df,

--- a/R/add_expenditure_item_share_income.R
+++ b/R/add_expenditure_item_share_income.R
@@ -26,6 +26,7 @@
 #' * `{expenditure_type}_share_income`: Recall-normalised share of expenditure relative to income, or `NA` if income is 0 or `NA`.
 #' * `{expenditure_type}_share_income_d`: `1L` if share >= `catastrophic_threshold`, `0L` if below, `NA_integer_` if share is `NA`.
 #'
+#' @family expenditure_share_income
 #' @export
 add_expenditure_type_share_income <- function(
   df,

--- a/R/add_expenditure_item_share_income.R
+++ b/R/add_expenditure_item_share_income.R
@@ -1,0 +1,104 @@
+#' @title Add Expenditure Item Share of Income and Catastrophic Spending Flag
+#'
+#' @description
+#' Calculates the share of a single expenditure item relative to total income normalising both to the same recall period before computing the ratio, and flags households where that share meets or exceeds the catastrophic threshold.
+#'
+#' The share is computed as: `(expenditure * income_recall_period) / (income * expenditure_recall_period)`
+#'
+#' Prerequisite: `cm_income_total` (or the column supplied to `income_total`)
+#' must already be present in `df`, either from the survey directly or from
+#' `add_income_source_prop()`.
+#'
+#' @param df A data frame.
+#' @param expenditure_type Column name for the expenditure amount.
+#' @param income_total Column name for the total household income.
+#' @param expenditure_recall_period Recall period of the expenditure column in
+#'   days. Default: `30`.
+#' @param income_recall_period Recall period of the income column in days.
+#'   Default: `30`.
+#' @param catastrophic_threshold Numeric threshold above which spending is
+#'   considered catastrophic (proportion, e.g. `0.25` for 25%).
+#'   Default: `0.25`.
+#'
+#' @return A data frame with two additional columns (names derived from
+#'   `expenditure_type`):
+#'
+#' * `{expenditure_type}_share_income`: Recall-normalised share of expenditure relative to income, or `NA` if income is 0 or `NA`.
+#' * `{expenditure_type}_share_income_d`: `1L` if share >= `catastrophic_threshold`, `0L` if below, `NA_integer_` if share is `NA`.
+#'
+#' @export
+add_expenditure_type_share_income <- function(
+  df,
+  expenditure_type,
+  income_total = "cm_income_total",
+  expenditure_recall_period = 30,
+  income_recall_period = 30,
+  catastrophic_threshold = 0.25
+) {
+  #------ Checks
+
+  # df is a df, expenditure_type and income_total columns exist, are numeric, and have non-negative values
+  # NOTE: are_values_in_range currently only errors when ALL columns have
+  # out-of-range values (bug fixed in PR #680).
+  are_values_in_range(
+    df,
+    c(expenditure_type, income_total),
+    lower = 0,
+    upper = Inf
+  )
+
+  # income_recall_period and expenditure_recall_period must be single stricly positive numeric values
+  if (
+    !is.numeric(expenditure_recall_period) ||
+      length(expenditure_recall_period) != 1 ||
+      expenditure_recall_period <= 0
+  ) {
+    cli::cli_abort(
+      "`expenditure_recall_period` must be a single strictly positive numeric value."
+    )
+  }
+
+  if (
+    !is.numeric(income_recall_period) ||
+      length(income_recall_period) != 1 ||
+      income_recall_period <= 0
+  ) {
+    cli::cli_abort(
+      "`income_recall_period` must be a single strictly positive numeric value."
+    )
+  }
+
+  # catastrophic_threshold must be a single numeric value in (0, 1)
+  if (
+    !is.numeric(catastrophic_threshold) ||
+      length(catastrophic_threshold) != 1 ||
+      catastrophic_threshold <= 0 ||
+      catastrophic_threshold >= 1
+  ) {
+    cli::cli_abort(
+      "`catastrophic_threshold` must be a single numeric value in (0, 1)."
+    )
+  }
+
+  #------ Compute recall-normalised share and flag
+
+  share_col <- paste0(expenditure_type, "_share_income")
+  dummy_col <- paste0(expenditure_type, "_share_income_d")
+
+  df <- dplyr::mutate(
+    df,
+    "{share_col}" := dplyr::if_else(
+      is.na(.data[[income_total]]) | .data[[income_total]] == 0,
+      NA_real_,
+      (.data[[expenditure_type]] * income_recall_period) /
+        (.data[[income_total]] * expenditure_recall_period)
+    ),
+    "{dummy_col}" := dplyr::case_when(
+      is.na(.data[[share_col]]) ~ NA_integer_,
+      .data[[share_col]] >= catastrophic_threshold ~ 1L,
+      .default = 0L
+    )
+  )
+
+  return(df)
+}

--- a/R/add_expenditure_item_share_income.R
+++ b/R/add_expenditure_item_share_income.R
@@ -1,7 +1,7 @@
-#' @title Add Expenditure Item Share of Income and Catastrophic Spending Flag
+#' @title Add Expenditure Type Share of Income and Catastrophic Spending Flag
 #'
 #' @description
-#' Calculates the share of a single expenditure item relative to total income normalising both to the same recall period before computing the ratio, and flags households where that share meets or exceeds the catastrophic threshold.
+#' Calculates the share of a single expenditure type relative to total income normalising both to the same recall period before computing the ratio, and flags households where that share meets or exceeds the catastrophic threshold.
 #'
 #' The share is computed as: `(expenditure * income_recall_period) / (income * expenditure_recall_period)`
 #'

--- a/R/add_expenditure_item_share_income.R
+++ b/R/add_expenditure_item_share_income.R
@@ -48,7 +48,7 @@ add_expenditure_type_share_income <- function(
     upper = Inf
   )
 
-  # income_recall_period and expenditure_recall_period must be single stricly positive numeric values
+  # income_recall_period and expenditure_recall_period must be single strictly positive numeric values
   if (
     !is.numeric(expenditure_recall_period) ||
       length(expenditure_recall_period) != 1 ||

--- a/R/add_expenditure_water_share_income.R
+++ b/R/add_expenditure_water_share_income.R
@@ -29,6 +29,7 @@
 #' * `cm_expenditure_frequent_water_share_income_d`: `1L` if catastrophic
 #'   (share >= 0.05), `0L` otherwise, `NA` if share is `NA`.
 #'
+#' @family expenditure_share_income
 #' @export
 add_expenditure_water_share_income <- function(
   df,

--- a/R/add_expenditure_water_share_income.R
+++ b/R/add_expenditure_water_share_income.R
@@ -1,0 +1,46 @@
+# ANA
+# 2025 Indicator ID: IND097
+# 2025 Metric ID: TBD
+
+#' @title Add Water Expenditure Share of Income
+#'
+#' @description
+#' Calculates the share of frequent water expenditure relative to total
+#' household income and flags households spending 5% or more of income on water
+#' (catastrophic water spending).
+#'
+#' This is a convenience wrapper around `add_expenditure_type_share_income()`
+#' with fixed parameters for the water expenditure module: both expenditure and
+#' income recall periods are 30 days, and the catastrophic threshold is 0.05
+#' (5%).
+#'
+#' Prerequisite: run `add_expenditure_type_zero_freq()` before calling this
+#' function. `cm_income_total` must also be present in `df`, either directly
+#' from the survey or via `add_income_source_prop()`.
+#'
+#' @param df A data frame.
+#' @param expenditure_type Column name for frequent water expenditure amount.
+#' @param total_income Column name for total household income.
+#'
+#' @return A data frame with two additional columns:
+#'
+#' * `cm_expenditure_frequent_water_share_income`: Water expenditure share of
+#'   income, or `NA` if income is 0 or `NA`.
+#' * `cm_expenditure_frequent_water_share_income_d`: `1L` if catastrophic
+#'   (share >= 0.05), `0L` otherwise, `NA` if share is `NA`.
+#'
+#' @export
+add_expenditure_water_share_income <- function(
+  df,
+  expenditure_type = "cm_expenditure_frequent_water",
+  total_income = "cm_income_total"
+) {
+  add_expenditure_type_share_income(
+    df,
+    expenditure_type = expenditure_type,
+    income_total = total_income,
+    expenditure_recall_period = 30,
+    income_recall_period = 30,
+    catastrophic_threshold = 0.05
+  )
+}

--- a/R/internals.R
+++ b/R/internals.R
@@ -55,7 +55,7 @@ are_values_in_range <- function(df, cols, lower = 0, upper = 7) {
 
   cols <- cols[ranges]
 
-  if (all(ranges)) {
+  if (any(ranges)) {
     rlang::abort(c(
       glue::glue("All columns must be between {lower} and {upper}."),
       "i" = glue::glue(

--- a/tests/testthat/test-add_expenditure_healthcare_share_income.R
+++ b/tests/testthat/test-add_expenditure_healthcare_share_income.R
@@ -1,0 +1,83 @@
+# ---- add_expenditure_healthcare_share_income ----
+
+make_df <- function(health = 20, income = 200) {
+  dplyr::tibble(
+    cm_expenditure_infrequent_health = health,
+    cm_income_total = income
+  )
+}
+
+test_that("add_expenditure_healthcare_share_income adds expected columns with defaults", {
+  result <- add_expenditure_healthcare_share_income(make_df())
+  expect_true(
+    "cm_expenditure_infrequent_health_share_income" %in% colnames(result)
+  )
+  expect_true(
+    "cm_expenditure_infrequent_health_share_income_d" %in% colnames(result)
+  )
+})
+
+test_that("default recall periods are 180d expenditure / 30d income", {
+  # share = (health/180) / (income/30) = health * 30 / (income * 180)
+  # health=60, income=100 → share = 60*30 / (100*180) = 1800/18000 = 0.10
+  result <- add_expenditure_healthcare_share_income(
+    dplyr::tibble(cm_expenditure_infrequent_health = 60, cm_income_total = 100)
+  )
+  expect_equal(result$cm_expenditure_infrequent_health_share_income, 0.10)
+})
+
+test_that("default catastrophic_threshold is 0.10 with 180/30 recall: below → 0, at → 1", {
+  # share = health * 30 / (100 * 180); threshold at health=60
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = c(59, 60, 61),
+    cm_income_total = rep(100, 3)
+  )
+  result <- add_expenditure_healthcare_share_income(df)
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income_d,
+    c(0L, 1L, 1L)
+  )
+})
+
+test_that("custom catastrophic_threshold is forwarded", {
+  # share = health * 30 / (100 * 180); threshold 0.25 at health=150
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = c(149, 150),
+    cm_income_total = rep(100, 2)
+  )
+  result <- add_expenditure_healthcare_share_income(
+    df,
+    catastrophic_threshold = 0.25
+  )
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income_d,
+    c(0L, 1L)
+  )
+})
+
+test_that("custom recall periods are forwarded", {
+  # With equal 30/30 recall: share = health/income; threshold at health=10 for income=100
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = c(9, 10),
+    cm_income_total = rep(100, 2)
+  )
+  result <- add_expenditure_healthcare_share_income(
+    df,
+    expenditure_recall_period = 30,
+    income_recall_period = 30
+  )
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income_d,
+    c(0L, 1L)
+  )
+})
+
+test_that("errors on missing health expenditure column", {
+  df <- dplyr::tibble(cm_income_total = 200)
+  expect_error(add_expenditure_healthcare_share_income(df))
+})
+
+test_that("errors on missing income column", {
+  df <- dplyr::tibble(cm_expenditure_infrequent_health = 20)
+  expect_error(add_expenditure_healthcare_share_income(df))
+})

--- a/tests/testthat/test-add_expenditure_healthcare_share_income.R
+++ b/tests/testthat/test-add_expenditure_healthcare_share_income.R
@@ -26,49 +26,16 @@ test_that("default recall periods are 180d expenditure / 30d income", {
   expect_equal(result$cm_expenditure_infrequent_health_share_income, 0.10)
 })
 
-test_that("default catastrophic_threshold is 0.10 with 180/30 recall: below → 0, at → 1", {
-  # share = health * 30 / (100 * 180); threshold at health=60
+test_that("default catastrophic_threshold is 0.25 with 180/30 recall: below → 0, at → 1", {
+  # share = health * 30 / (100 * 180); threshold 0.25 at health=150
   df <- dplyr::tibble(
-    cm_expenditure_infrequent_health = c(59, 60, 61),
+    cm_expenditure_infrequent_health = c(149, 150, 151),
     cm_income_total = rep(100, 3)
   )
   result <- add_expenditure_healthcare_share_income(df)
   expect_equal(
     result$cm_expenditure_infrequent_health_share_income_d,
     c(0L, 1L, 1L)
-  )
-})
-
-test_that("custom catastrophic_threshold is forwarded", {
-  # share = health * 30 / (100 * 180); threshold 0.25 at health=150
-  df <- dplyr::tibble(
-    cm_expenditure_infrequent_health = c(149, 150),
-    cm_income_total = rep(100, 2)
-  )
-  result <- add_expenditure_healthcare_share_income(
-    df,
-    catastrophic_threshold = 0.25
-  )
-  expect_equal(
-    result$cm_expenditure_infrequent_health_share_income_d,
-    c(0L, 1L)
-  )
-})
-
-test_that("custom recall periods are forwarded", {
-  # With equal 30/30 recall: share = health/income; threshold at health=10 for income=100
-  df <- dplyr::tibble(
-    cm_expenditure_infrequent_health = c(9, 10),
-    cm_income_total = rep(100, 2)
-  )
-  result <- add_expenditure_healthcare_share_income(
-    df,
-    expenditure_recall_period = 30,
-    income_recall_period = 30
-  )
-  expect_equal(
-    result$cm_expenditure_infrequent_health_share_income_d,
-    c(0L, 1L)
   )
 })
 

--- a/tests/testthat/test-add_expenditure_item_share_income.R
+++ b/tests/testthat/test-add_expenditure_item_share_income.R
@@ -1,0 +1,308 @@
+# ---- add_expenditure_type_share_income ----
+
+make_df <- function(health = 20, income = 200) {
+  dplyr::tibble(
+    cm_expenditure_infrequent_health = health,
+    cm_income_total = income
+  )
+}
+
+# ---- Output columns ----
+
+test_that("add_expenditure_type_share_income adds _share_income column", {
+  result <- add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(
+    "cm_expenditure_infrequent_health_share_income" %in% colnames(result)
+  )
+})
+
+test_that("add_expenditure_type_share_income adds _share_income_d column", {
+  result <- add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(
+    "cm_expenditure_infrequent_health_share_income_d" %in% colnames(result)
+  )
+})
+
+test_that("output column names are dynamic based on expenditure_type", {
+  df <- dplyr::tibble(cm_expenditure_other = 10, cm_income_total = 100)
+  result <- add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_other",
+    income_total = "cm_income_total"
+  )
+  expect_true("cm_expenditure_other_share_income" %in% colnames(result))
+  expect_true("cm_expenditure_other_share_income_d" %in% colnames(result))
+})
+
+# ---- Share calculation ----
+
+test_that("_share_income equals expenditure / income when recall periods are equal", {
+  # (20/30) / (200/30) = 20/200 = 0.1
+  result <- add_expenditure_type_share_income(
+    make_df(health = 20, income = 200),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_equal(result$cm_expenditure_infrequent_health_share_income, 0.1)
+})
+
+test_that("_share_income is NA when income is 0", {
+  result <- add_expenditure_type_share_income(
+    make_df(health = 0, income = 0),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(is.na(result$cm_expenditure_infrequent_health_share_income))
+})
+
+test_that("_share_income is NA when income is NA", {
+  result <- add_expenditure_type_share_income(
+    make_df(health = 20, income = NA_real_),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(is.na(result$cm_expenditure_infrequent_health_share_income))
+})
+
+test_that("_share_income is NA when expenditure is NA", {
+  result <- add_expenditure_type_share_income(
+    make_df(health = NA_real_, income = 200),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(is.na(result$cm_expenditure_infrequent_health_share_income))
+})
+
+# ---- Dummy flag ----
+
+test_that("_share_income_d is 0 when share < catastrophic_threshold", {
+  # share = 9/100 = 0.09 < 0.10
+  result <- add_expenditure_type_share_income(
+    make_df(health = 9, income = 100),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 0.10
+  )
+  expect_equal(result$cm_expenditure_infrequent_health_share_income_d, 0L)
+})
+
+test_that("_share_income_d is 1 when share == catastrophic_threshold", {
+  # share = 10/100 = 0.10
+  result <- add_expenditure_type_share_income(
+    make_df(health = 10, income = 100),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 0.10
+  )
+  expect_equal(result$cm_expenditure_infrequent_health_share_income_d, 1L)
+})
+
+test_that("_share_income_d is 1 when share > catastrophic_threshold", {
+  # share = 30/100 = 0.30 > 0.10
+  result <- add_expenditure_type_share_income(
+    make_df(health = 30, income = 100),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 0.10
+  )
+  expect_equal(result$cm_expenditure_infrequent_health_share_income_d, 1L)
+})
+
+test_that("_share_income_d is NA when share is NA", {
+  result <- add_expenditure_type_share_income(
+    make_df(health = 0, income = 0),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_true(is.na(result$cm_expenditure_infrequent_health_share_income_d))
+})
+
+test_that("_share_income_d is integer type", {
+  result <- add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  )
+  expect_type(result$cm_expenditure_infrequent_health_share_income_d, "integer")
+})
+
+test_that("catastrophic_threshold is respected with custom value", {
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = c(24, 25, 26),
+    cm_income_total = rep(100, 3)
+  )
+  result <- add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 0.25
+  )
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income_d,
+    c(0L, 1L, 1L)
+  )
+})
+
+# ---- Recall period normalisation ----
+
+test_that("different recall periods normalise correctly", {
+  # expenditure = 60 over 180 days → 1/3 per day
+  # income = 100 over 30 days → 100/30 per day
+  # share = (1/3) / (100/30) = (60/180) / (100/30) = 0.10
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = 60,
+    cm_income_total = 100
+  )
+  result <- add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    expenditure_recall_period = 180,
+    income_recall_period = 30
+  )
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income,
+    60 * 30 / (100 * 180)
+  )
+})
+
+test_that("recall period normalisation affects catastrophic flag", {
+  # health = 60/180d, income = 100/30d → share = 0.10 → just at threshold
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = c(59, 60, 61),
+    cm_income_total = rep(100, 3)
+  )
+  result <- add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    expenditure_recall_period = 180,
+    income_recall_period = 30,
+    catastrophic_threshold = 0.10
+  )
+  expect_equal(
+    result$cm_expenditure_infrequent_health_share_income_d,
+    c(0L, 1L, 1L)
+  )
+})
+
+# ---- Errors ----
+
+test_that("errors on missing expenditure column", {
+  df <- dplyr::tibble(cm_income_total = 200)
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on missing income column", {
+  df <- dplyr::tibble(cm_expenditure_infrequent_health = 20)
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on non-numeric expenditure column", {
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = "high",
+    cm_income_total = 200
+  )
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on non-numeric income column", {
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = 20,
+    cm_income_total = "high"
+  )
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on negative expenditure values", {
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = -10,
+    cm_income_total = 200
+  )
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on negative income values", {
+  df <- dplyr::tibble(
+    cm_expenditure_infrequent_health = 20,
+    cm_income_total = -100
+  )
+  expect_error(add_expenditure_type_share_income(
+    df,
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total"
+  ))
+})
+
+test_that("errors on non-positive expenditure_recall_period", {
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    expenditure_recall_period = 0
+  ))
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    expenditure_recall_period = -30
+  ))
+})
+
+test_that("errors on non-positive income_recall_period", {
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    income_recall_period = 0
+  ))
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    income_recall_period = -30
+  ))
+})
+
+test_that("errors on catastrophic_threshold outside (0, 1)", {
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 0
+  ))
+  expect_error(add_expenditure_type_share_income(
+    make_df(),
+    expenditure_type = "cm_expenditure_infrequent_health",
+    income_total = "cm_income_total",
+    catastrophic_threshold = 1
+  ))
+})

--- a/tests/testthat/test-add_expenditure_water_share_income.R
+++ b/tests/testthat/test-add_expenditure_water_share_income.R
@@ -1,0 +1,58 @@
+# ---- add_expenditure_water_share_income ----
+
+make_df <- function(water = 10, income = 200) {
+  dplyr::tibble(
+    cm_expenditure_frequent_water = water,
+    cm_income_total = income
+  )
+}
+
+test_that("add_expenditure_water_share_income adds expected columns with defaults", {
+  result <- add_expenditure_water_share_income(make_df())
+  expect_true(
+    "cm_expenditure_frequent_water_share_income" %in% colnames(result)
+  )
+  expect_true(
+    "cm_expenditure_frequent_water_share_income_d" %in% colnames(result)
+  )
+})
+
+test_that("default recall periods are 30d / 30d (share = water / income)", {
+  # share = 10 / 200 = 0.05
+  result <- add_expenditure_water_share_income(make_df(water = 10, income = 200))
+  expect_equal(result$cm_expenditure_frequent_water_share_income, 0.05)
+})
+
+test_that("default catastrophic_threshold is 0.05: below → 0, at → 1, above → 1", {
+  # threshold at water = 5 for income = 100
+  df <- dplyr::tibble(
+    cm_expenditure_frequent_water = c(4, 5, 6),
+    cm_income_total = rep(100, 3)
+  )
+  result <- add_expenditure_water_share_income(df)
+  expect_equal(
+    result$cm_expenditure_frequent_water_share_income_d,
+    c(0L, 1L, 1L)
+  )
+})
+
+test_that("share is NA when income is 0", {
+  result <- add_expenditure_water_share_income(make_df(water = 10, income = 0))
+  expect_true(is.na(result$cm_expenditure_frequent_water_share_income))
+  expect_true(is.na(result$cm_expenditure_frequent_water_share_income_d))
+})
+
+test_that("share is NA when income is NA", {
+  result <- add_expenditure_water_share_income(make_df(water = 10, income = NA_real_))
+  expect_true(is.na(result$cm_expenditure_frequent_water_share_income))
+})
+
+test_that("errors on missing water expenditure column", {
+  df <- dplyr::tibble(cm_income_total = 200)
+  expect_error(add_expenditure_water_share_income(df))
+})
+
+test_that("errors on missing income column", {
+  df <- dplyr::tibble(cm_expenditure_frequent_water = 10)
+  expect_error(add_expenditure_water_share_income(df))
+})

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -22,6 +22,15 @@ df_non_numeric <- data.frame(
   col2 = c(1, 2, 3)
 )
 
+# Test data setup
+df_wrong_range <- data.frame(
+  col1 = c(1, 2, 3, 4, NA),
+  col2 = c("a", "b", "c", "d", NA),
+  col3 = c(7, 8, 9, 10, NA),
+  col4 = c(3, 4, 5, 6, NA),
+  col5 = c(NA, NA, NA, NA, NA)
+)
+
 test_that("are_cols_numeric works with default parameters", {
   expect_true(humind:::are_cols_numeric(df, c("col1", "col3", "col4")))
 })
@@ -45,7 +54,7 @@ test_that("are_cols_numeric handles all NA columns", {
 })
 
 test_that("are_values_in_range works with default parameters", {
-  expect_true(humind:::are_values_in_range(df, c("col1", "col3", "col4")))
+  expect_true(humind:::are_values_in_range(df, c("col1", "col4")))
 })
 
 test_that("are_values_in_range handles values out of range", {
@@ -61,6 +70,15 @@ test_that("are_values_in_range handles missing columns", {
   expect_error(
     humind:::are_values_in_range(df, c("col1", "col6")),
     class = "error"
+  )
+})
+
+test_that("are_values_in_range throws error when any column has values out of range", {
+  # col1 is within range (0-7), but col3 contains values > 7 (specifically 8, 9, 10)
+  # The function should detect the invalid values in col3 and throw an error
+  expect_error(
+    humind:::are_values_in_range(df_wrong_range, c("col1", "col3")),
+    "outside the range"
   )
 })
 


### PR DESCRIPTION
## Summary

- Add `add_expenditure_type_share_income()`: generic function computing recall-normalised expenditure share of income and a catastrophic spending flag (`_share_income`, `_share_income_d`)
- Add `add_expenditure_healthcare_share_income()`: convenience wrapper for IND162 with fixed parameters (180d expenditure / 30d income recall, 0.25 threshold)
- Add `add_expenditure_water_share_income()`: convenience wrapper for IND097 with fixed parameters (30d/30d recall, 0.05 threshold)
- Cherry-pick `are_values_in_range` fix from #680 so validation errors when **any** column is out of range, not only when all are

Closes #689

## Test plan

- `testthat::test_file("tests/testthat/test-add_expenditure_item_share_income.R")` — 28 tests covering share calculation, NA propagation, recall normalisation, dummy flag, and errors
- `testthat::test_file("tests/testthat/test-add_expenditure_healthcare_share_income.R")` — 6 tests for IND162 wrapper
- `testthat::test_file("tests/testthat/test-add_expenditure_water_share_income.R")` — 9 tests for IND097 wrapper