### PR TITLE
feat(wash): add add_water_access_issue_physical() and add_water_access_issue_financial()

### DIFF
--- a/R/add_water_access_issue.R
+++ b/R/add_water_access_issue.R
@@ -4,27 +4,19 @@
 
 #' @title Add Physical Water Access Issue Indicator
 #'
-#' @description
-#' Computes a binary variable (`wash_water_access_issue_physical_d`) that is
-#' `1` if the household reported any physical barrier to accessing water points
-#' (too far, difficult to use, disability-related barriers, or excessive waiting
-#' time), `0` if none were reported, and `NA` if the response was ambiguous
-#' (dnk/pnta/other) or the household has no water source (`wash_drinking_water_source = 'none'`).
+#' @description Computes a binary variable (`wash_water_access_issue_physical_d`) that is `1L` if the household reported any physical barrier to accessing water points (too far, difficult to use, disability-related barriers, safety concerns, or excessive waiting time), `0L` if none were reported, and `NA` if the response was ambiguous (dnk/pnta/other) or the household has no water source (`wash_drinking_water_source = 'none'`).
 #'
 #' @param df A data frame.
 #' @param water_access_issue Base name of the select_multiple variable.
-#' @param physical Character vector of responses that indicate physical access
-#'   barriers.
+#' @param physical Character vector of responses that indicate physical access barriers.
 #' @param undefined Character vector of undefined responses (dnk, pnta, other).
 #' @param water_source Column name for the water source type.
 #' @param none Response code for no water source.
-#' @param sep Separator between the base name and response code in binary
-#'   column names.
+#' @param sep Separator between the base name and response code in binary column names.
 #'
 #' @return A data frame with one additional column:
 #'
-#' * `wash_water_access_issue_physical_d`: `1` if any physical barrier is
-#'   reported; `0` if none; `NA` if undefined response or no water source.
+#' * `wash_water_access_issue_physical_d`: `1L` if any physical barrier is reported; `0L` if none; `NA` if undefined response or no water source.
 #'
 #' @family water_access_issue
 #' @export
@@ -35,6 +27,8 @@ add_water_access_issue_physical <- function(
     "waterpoints_too_far",
     "waterpoints_difficult_use",
     "disability_no_access_waterpoints",
+    "safety_concerns_waterpoints",
+    "safety_concerns_travel_waterpoints",
     "excessive_waiting_time_waterpoints"
   ),
   undefined = c("dnk", "pnta", "other"),
@@ -56,10 +50,10 @@ add_water_access_issue_physical <- function(
   df <- dplyr::mutate(
     df,
     wash_water_access_issue_physical_d = dplyr::case_when(
-      .data[[water_source]] %in% none ~ NA_real_,
-      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_real_,
-      dplyr::if_any(dplyr::all_of(d_physical), \(x) x == 1) ~ 1,
-      .default = 0
+      .data[[water_source]] %in% none ~ NA_integer_,
+      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_integer_,
+      dplyr::if_any(dplyr::all_of(d_physical), \(x) x == 1) ~ 1L,
+      .default = 0L
     )
   )
 
@@ -71,21 +65,13 @@ add_water_access_issue_physical <- function(
 #'
 #' @title Add Financial Water Access Issue Indicator
 #'
-#' @description
-#' Computes a binary variable (`wash_water_access_issue_financial_d`) that is
-#' `1` if the household reported any financial barrier to accessing water
-#' (water not available at market, too expensive, or insufficient storage
-#' containers), `0` if none were reported, and `NA` if the response was
-#' ambiguous (dnk/pnta/other) or the household has no water source
-#' (`wash_drinking_water_source = 'none'`).
+#' @description Computes a binary variable (`wash_water_access_issue_financial_d`) that is `1L` if the household reported any financial barrier to accessing water (water not available at market, too expensive, or insufficient storage containers), `0L` if none were reported, and `NA` if the response was ambiguous (dnk/pnta/other) or the household has no water source (`wash_drinking_water_source = 'none'`).
 #'
-#' @param financial Character vector of responses that indicate financial access
-#'   barriers.
+#' @param financial Character vector of responses that indicate financial access barriers.
 #'
 #' @return A data frame with one additional column:
 #'
-#' * `wash_water_access_issue_financial_d`: `1` if any financial barrier is
-#'   reported; `0` if none; `NA` if undefined response or no water source.
+#' * `wash_water_access_issue_financial_d`: `1L` if any financial barrier is reported; `0L` if none; `NA` if undefined response or no water source.
 #'
 #' @family water_access_issue
 #' @export
@@ -116,10 +102,10 @@ add_water_access_issue_financial <- function(
   df <- dplyr::mutate(
     df,
     wash_water_access_issue_financial_d = dplyr::case_when(
-      .data[[water_source]] %in% none ~ NA_real_,
-      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_real_,
-      dplyr::if_any(dplyr::all_of(d_financial), \(x) x == 1) ~ 1,
-      .default = 0
+      .data[[water_source]] %in% none ~ NA_integer_,
+      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_integer_,
+      dplyr::if_any(dplyr::all_of(d_financial), \(x) x == 1) ~ 1L,
+      .default = 0L
     )
   )
 

--- a/R/add_water_access_issue.R
+++ b/R/add_water_access_issue.R
@@ -1,0 +1,127 @@
+# ANA
+# 2025 Indicator ID: IND098 and IND099
+# 2025 Metric ID: TBD
+
+#' @title Add Physical Water Access Issue Indicator
+#'
+#' @description
+#' Computes a binary variable (`wash_water_access_issue_physical_d`) that is
+#' `1` if the household reported any physical barrier to accessing water points
+#' (too far, difficult to use, disability-related barriers, or excessive waiting
+#' time), `0` if none were reported, and `NA` if the response was ambiguous
+#' (dnk/pnta/other) or the household has no water source (`wash_drinking_water_source = 'none'`).
+#'
+#' @param df A data frame.
+#' @param water_access_issue Base name of the select_multiple variable.
+#' @param physical Character vector of responses that indicate physical access
+#'   barriers.
+#' @param undefined Character vector of undefined responses (dnk, pnta, other).
+#' @param water_source Column name for the water source type.
+#' @param none Response code for no water source.
+#' @param sep Separator between the base name and response code in binary
+#'   column names.
+#'
+#' @return A data frame with one additional column:
+#'
+#' * `wash_water_access_issue_physical_d`: `1` if any physical barrier is
+#'   reported; `0` if none; `NA` if undefined response or no water source.
+#'
+#' @family water_access_issue
+#' @export
+add_water_access_issue_physical <- function(
+  df,
+  water_access_issue = "wash_water_access_issue",
+  physical = c(
+    "waterpoints_too_far",
+    "waterpoints_difficult_use",
+    "disability_no_access_waterpoints",
+    "excessive_waiting_time_waterpoints"
+  ),
+  undefined = c("dnk", "pnta", "other"),
+  water_source = "wash_drinking_water_source",
+  none = "none",
+  sep = "/"
+) {
+  #------ Checks
+
+  if_not_in_stop(df, water_access_issue, "df")
+  if_not_in_stop(df, water_source, "df")
+
+  d_physical <- paste0(water_access_issue, sep, physical)
+  d_undefined <- paste0(water_access_issue, sep, undefined)
+  are_values_in_set(df, c(d_physical, d_undefined), c(0, 1))
+
+  #------ Compute
+
+  df <- dplyr::mutate(
+    df,
+    wash_water_access_issue_physical_d = dplyr::case_when(
+      .data[[water_source]] %in% none ~ NA_real_,
+      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_real_,
+      dplyr::if_any(dplyr::all_of(d_physical), \(x) x == 1) ~ 1,
+      .default = 0
+    )
+  )
+
+  return(df)
+}
+
+
+#' @rdname add_water_access_issue_physical
+#'
+#' @title Add Financial Water Access Issue Indicator
+#'
+#' @description
+#' Computes a binary variable (`wash_water_access_issue_financial_d`) that is
+#' `1` if the household reported any financial barrier to accessing water
+#' (water not available at market, too expensive, or insufficient storage
+#' containers), `0` if none were reported, and `NA` if the response was
+#' ambiguous (dnk/pnta/other) or the household has no water source
+#' (`wash_drinking_water_source = 'none'`).
+#'
+#' @param financial Character vector of responses that indicate financial access
+#'   barriers.
+#'
+#' @return A data frame with one additional column:
+#'
+#' * `wash_water_access_issue_financial_d`: `1` if any financial barrier is
+#'   reported; `0` if none; `NA` if undefined response or no water source.
+#'
+#' @family water_access_issue
+#' @export
+add_water_access_issue_financial <- function(
+  df,
+  water_access_issue = "wash_water_access_issue",
+  financial = c(
+    "water_not_available_market",
+    "water_too_expensive",
+    "not_enough_containers"
+  ),
+  undefined = c("dnk", "pnta", "other"),
+  water_source = "wash_drinking_water_source",
+  none = "none",
+  sep = "/"
+) {
+  #------ Checks
+
+  if_not_in_stop(df, water_access_issue, "df")
+  if_not_in_stop(df, water_source, "df")
+
+  d_financial <- paste0(water_access_issue, sep, financial)
+  d_undefined <- paste0(water_access_issue, sep, undefined)
+  are_values_in_set(df, c(d_financial, d_undefined), c(0, 1))
+
+  #------ Compute
+
+  df <- dplyr::mutate(
+    df,
+    wash_water_access_issue_financial_d = dplyr::case_when(
+      .data[[water_source]] %in% none ~ NA_real_,
+      dplyr::if_any(dplyr::all_of(d_undefined), \(x) x == 1) ~ NA_real_,
+      dplyr::if_any(dplyr::all_of(d_financial), \(x) x == 1) ~ 1,
+      .default = 0
+    )
+  )
+
+  return(df)
+}

--- a/tests/testthat/test-add_water_access_issue.R
+++ b/tests/testthat/test-add_water_access_issue.R
@@ -3,6 +3,8 @@ make_df <- function(
   too_far = 0L,
   difficult_use = 0L,
   disability = 0L,
+  safety = 0L,
+  safety_travel = 0L,
   waiting_time = 0L,
   not_available = 0L,
   too_expensive = 0L,
@@ -18,6 +20,8 @@ make_df <- function(
     `wash_water_access_issue/waterpoints_too_far` = too_far,
     `wash_water_access_issue/waterpoints_difficult_use` = difficult_use,
     `wash_water_access_issue/disability_no_access_waterpoints` = disability,
+    `wash_water_access_issue/safety_concerns_waterpoints` = safety,
+    `wash_water_access_issue/safety_concerns_travel_waterpoints` = safety_travel,
     `wash_water_access_issue/excessive_waiting_time_waterpoints` = waiting_time,
     `wash_water_access_issue/water_not_available_market` = not_available,
     `wash_water_access_issue/water_too_expensive` = too_expensive,
@@ -29,27 +33,37 @@ make_df <- function(
   )
 }
 
-# ---- add_water_access_issue_physical ----
+
+#########################################
+### add_water_access_issue_physical
+#########################################
 
 test_that("add_water_access_issue_physical returns wash_water_access_issue_physical_d", {
   result <- add_water_access_issue_physical(make_df())
   expect_true("wash_water_access_issue_physical_d" %in% colnames(result))
 })
 
-test_that("add_water_access_issue_physical is 0 when no physical option selected", {
+test_that("output is integer type", {
   result <- add_water_access_issue_physical(make_df())
-  expect_equal(result$wash_water_access_issue_physical_d, 0)
+  expect_type(result$wash_water_access_issue_physical_d, "integer")
 })
 
-test_that("add_water_access_issue_physical is 1 for each physical option individually", {
+test_that("add_water_access_issue_physical is 0L when no physical option selected", {
+  result <- add_water_access_issue_physical(make_df())
+  expect_equal(result$wash_water_access_issue_physical_d, 0L)
+})
+
+test_that("add_water_access_issue_physical is 1L for each physical option individually", {
   df <- dplyr::bind_rows(
     make_df(too_far = 1L),
     make_df(difficult_use = 1L),
     make_df(disability = 1L),
+    make_df(safety = 1L),
+    make_df(safety_travel = 1L),
     make_df(waiting_time = 1L)
   )
   result <- add_water_access_issue_physical(df)
-  expect_equal(result$wash_water_access_issue_physical_d, rep(1, 4))
+  expect_equal(result$wash_water_access_issue_physical_d, rep(1L, 6))
 })
 
 test_that("add_water_access_issue_physical is NA for each undefined option", {
@@ -80,26 +94,34 @@ test_that("add_water_access_issue_physical errors when a dummy column is missing
   expect_error(add_water_access_issue_physical(df))
 })
 
-# ---- add_water_access_issue_financial ----
+
+#########################################
+### add_water_access_issue_financial
+#########################################
 
 test_that("add_water_access_issue_financial returns wash_water_access_issue_financial_d", {
   result <- add_water_access_issue_financial(make_df())
   expect_true("wash_water_access_issue_financial_d" %in% colnames(result))
 })
 
-test_that("add_water_access_issue_financial is 0 when no financial option selected", {
+test_that("output is integer type", {
   result <- add_water_access_issue_financial(make_df())
-  expect_equal(result$wash_water_access_issue_financial_d, 0)
+  expect_type(result$wash_water_access_issue_financial_d, "integer")
 })
 
-test_that("add_water_access_issue_financial is 1 for each financial option individually", {
+test_that("add_water_access_issue_financial is 0L when no financial option selected", {
+  result <- add_water_access_issue_financial(make_df())
+  expect_equal(result$wash_water_access_issue_financial_d, 0L)
+})
+
+test_that("add_water_access_issue_financial is 1L for each financial option individually", {
   df <- dplyr::bind_rows(
     make_df(not_available = 1L),
     make_df(too_expensive = 1L),
     make_df(no_containers = 1L)
   )
   result <- add_water_access_issue_financial(df)
-  expect_equal(result$wash_water_access_issue_financial_d, rep(1, 3))
+  expect_equal(result$wash_water_access_issue_financial_d, rep(1L, 3))
 })
 
 test_that("add_water_access_issue_financial is NA for each undefined option", {

--- a/tests/testthat/test-add_water_access_issue.R
+++ b/tests/testthat/test-add_water_access_issue.R
@@ -1,0 +1,131 @@
+# Helper: one row with all dummy columns set to 0 by default
+make_df <- function(
+  too_far = 0L,
+  difficult_use = 0L,
+  disability = 0L,
+  waiting_time = 0L,
+  not_available = 0L,
+  too_expensive = 0L,
+  no_containers = 0L,
+  dnk = 0L,
+  pnta = 0L,
+  other = 0L,
+  source = "piped_water"
+) {
+  dplyr::tibble(
+    wash_drinking_water_source = source,
+    wash_water_access_issue = "no_problem_access_water",
+    `wash_water_access_issue/waterpoints_too_far` = too_far,
+    `wash_water_access_issue/waterpoints_difficult_use` = difficult_use,
+    `wash_water_access_issue/disability_no_access_waterpoints` = disability,
+    `wash_water_access_issue/excessive_waiting_time_waterpoints` = waiting_time,
+    `wash_water_access_issue/water_not_available_market` = not_available,
+    `wash_water_access_issue/water_too_expensive` = too_expensive,
+    `wash_water_access_issue/not_enough_containers` = no_containers,
+    `wash_water_access_issue/dnk` = dnk,
+    `wash_water_access_issue/pnta` = pnta,
+    `wash_water_access_issue/other` = other,
+    .name_repair = "minimal"
+  )
+}
+
+# ---- add_water_access_issue_physical ----
+
+test_that("add_water_access_issue_physical returns wash_water_access_issue_physical_d", {
+  result <- add_water_access_issue_physical(make_df())
+  expect_true("wash_water_access_issue_physical_d" %in% colnames(result))
+})
+
+test_that("add_water_access_issue_physical is 0 when no physical option selected", {
+  result <- add_water_access_issue_physical(make_df())
+  expect_equal(result$wash_water_access_issue_physical_d, 0)
+})
+
+test_that("add_water_access_issue_physical is 1 for each physical option individually", {
+  df <- dplyr::bind_rows(
+    make_df(too_far = 1L),
+    make_df(difficult_use = 1L),
+    make_df(disability = 1L),
+    make_df(waiting_time = 1L)
+  )
+  result <- add_water_access_issue_physical(df)
+  expect_equal(result$wash_water_access_issue_physical_d, rep(1, 4))
+})
+
+test_that("add_water_access_issue_physical is NA for each undefined option", {
+  df <- dplyr::bind_rows(
+    make_df(dnk = 1L),
+    make_df(pnta = 1L),
+    make_df(other = 1L)
+  )
+  result <- add_water_access_issue_physical(df)
+  expect_true(all(is.na(result$wash_water_access_issue_physical_d)))
+})
+
+test_that("add_water_access_issue_physical is NA when water source is 'none'", {
+  result <- add_water_access_issue_physical(make_df(source = "none"))
+  expect_true(is.na(result$wash_water_access_issue_physical_d))
+})
+
+test_that("add_water_access_issue_physical errors when base column is missing", {
+  df <- dplyr::select(make_df(), -wash_water_access_issue)
+  expect_error(add_water_access_issue_physical(df))
+})
+
+test_that("add_water_access_issue_physical errors when a dummy column is missing", {
+  df <- dplyr::select(
+    make_df(),
+    -`wash_water_access_issue/waterpoints_too_far`
+  )
+  expect_error(add_water_access_issue_physical(df))
+})
+
+# ---- add_water_access_issue_financial ----
+
+test_that("add_water_access_issue_financial returns wash_water_access_issue_financial_d", {
+  result <- add_water_access_issue_financial(make_df())
+  expect_true("wash_water_access_issue_financial_d" %in% colnames(result))
+})
+
+test_that("add_water_access_issue_financial is 0 when no financial option selected", {
+  result <- add_water_access_issue_financial(make_df())
+  expect_equal(result$wash_water_access_issue_financial_d, 0)
+})
+
+test_that("add_water_access_issue_financial is 1 for each financial option individually", {
+  df <- dplyr::bind_rows(
+    make_df(not_available = 1L),
+    make_df(too_expensive = 1L),
+    make_df(no_containers = 1L)
+  )
+  result <- add_water_access_issue_financial(df)
+  expect_equal(result$wash_water_access_issue_financial_d, rep(1, 3))
+})
+
+test_that("add_water_access_issue_financial is NA for each undefined option", {
+  df <- dplyr::bind_rows(
+    make_df(dnk = 1L),
+    make_df(pnta = 1L),
+    make_df(other = 1L)
+  )
+  result <- add_water_access_issue_financial(df)
+  expect_true(all(is.na(result$wash_water_access_issue_financial_d)))
+})
+
+test_that("add_water_access_issue_financial is NA when water source is 'none'", {
+  result <- add_water_access_issue_financial(make_df(source = "none"))
+  expect_true(is.na(result$wash_water_access_issue_financial_d))
+})
+
+test_that("add_water_access_issue_financial errors when base column is missing", {
+  df <- dplyr::select(make_df(), -wash_water_access_issue)
+  expect_error(add_water_access_issue_financial(df))
+})
+
+test_that("add_water_access_issue_financial errors when a dummy column is missing", {
+  df <- dplyr::select(
+    make_df(),
+    -`wash_water_access_issue/water_too_expensive`
+  )
+  expect_error(add_water_access_issue_financial(df))
+})


### PR DESCRIPTION
## Summary

- Add `add_water_access_issue_physical()` (IND098): binary flag for households reporting physical barriers to water access (too far, difficult to use, disability-related, excessive waiting time)
- Add `add_water_access_issue_financial()` (IND099): binary flag for households reporting financial barriers to water access (not available at market, too expensive, not enough containers)
- Both follow the same pattern as `add_sanitation_access_issue_physical/social()` from #684
- Linked via `@family water_access_issue` in roxygen docs

Closes #668

## Test plan

- `testthat::test_file("tests/testthat/test-add_water_access_issue.R")` — 14 tests covering output column, 0/1/NA logic for each option individually, undefined responses, no water source, and missing column errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)