### PR TITLE
feat(snfi): replace "no_cannot" with "no" in add_fds_cannot_cat()

### DIFF
--- a/R/add_fds_cannot_cat.R
+++ b/R/add_fds_cannot_cat.R
@@ -108,19 +108,19 @@ add_fds_cannot_cat <- function(
     df,
     snfi_fds_cooking = dplyr::case_when(
       !!rlang::sym(fds_cooking) == fds_cooking_can ~ "yes",
-      !!rlang::sym(fds_cooking) == fds_cooking_cannot ~ "no_cannot",
+      !!rlang::sym(fds_cooking) == fds_cooking_cannot ~ "no",
       !!rlang::sym(fds_cooking) == fds_cooking_no_need ~ "no_no_need",
       !!rlang::sym(fds_cooking) == fds_cooking_undefined ~ "undefined",
       .default = NA_character_
     ),
     snfi_fds_sleeping = dplyr::case_when(
-      !!rlang::sym(fds_sleeping) == fds_sleeping_cannot ~ "no_cannot",
+      !!rlang::sym(fds_sleeping) == fds_sleeping_cannot ~ "no",
       !!rlang::sym(fds_sleeping) == fds_sleeping_can ~ "yes",
       !!rlang::sym(fds_sleeping) == fds_sleeping_undefined ~ "undefined",
       .default = NA_character_
     ),
     snfi_fds_storing = dplyr::case_when(
-      !!rlang::sym(fds_storing) == fds_storing_cannot ~ "no_cannot",
+      !!rlang::sym(fds_storing) == fds_storing_cannot ~ "no",
       !!rlang::sym(fds_storing) %in% fds_storing_can ~ "yes",
       !!rlang::sym(fds_storing) == fds_storing_undefined ~ "undefined",
       .default = NA_character_
@@ -134,14 +134,14 @@ add_fds_cannot_cat <- function(
     )
   )
 
-  #----- Sum across cols if "no_cannot"
+  #----- Sum across cols if "no"
   df <- dplyr::mutate(
     df,
     dplyr::across(
       c("snfi_fds_cooking", "snfi_fds_sleeping", "snfi_fds_storing"),
       \(x) {
         dplyr::case_when(
-          x == "no_cannot" ~ 1,
+          x == "no" ~ 1,
           x %in% c("yes", "no_no_need") ~ 0,
           .default = NA_real_
         )

--- a/tests/testthat/test-add_fds_cannot_cat.R
+++ b/tests/testthat/test-add_fds_cannot_cat.R
@@ -33,19 +33,19 @@ test_that("add_fds_cannot_cat works as expected", {
   # Check correct recoding for cooking
   expect_equal(
     result$snfi_fds_cooking,
-    c("yes", "no_cannot", "no_no_need", "undefined", "no_cannot")
+    c("yes", "no", "no_no_need", "undefined", "no")
   )
 
   # Check correct recoding for sleeping
   expect_equal(
     result$snfi_fds_sleeping,
-    c("yes", "no_cannot", "undefined", "yes", "no_cannot")
+    c("yes", "no", "undefined", "yes", "no")
   )
 
   # Check correct recoding for storing
   expect_equal(
     result$snfi_fds_storing,
-    c("yes", "no_cannot", "yes", "undefined", "no_cannot")
+    c("yes", "no", "yes", "undefined", "no")
   )
 
   # Check correct recoding for lighting


### PR DESCRIPTION
## Summary

- Replace output value `"no_cannot"` with `"no"` for `snfi_fds_cooking`, `snfi_fds_sleeping`, and `snfi_fds_storing` in `add_fds_cannot_cat()`, reflecting the 2026 FDS alignment where a "no" response maps directly to inability to perform the task
- Update the internal `case_when` used to sum cannot-tasks to match against `"no"` instead of `"no_cannot"`

Closes #701

## Test plan

- `testthat::test_file("tests/testthat/test-add_fds_cannot_cat.R")` - expected recode values updated from `"no_cannot"` to `"no"` for all three FDS columns

## Open questions (pending @mario-fidalgo)

- Should `fds_storing_can` default change from `c("yes_issues", "yes_no_issues")` to just `"yes"` for 2026?
- The current `fds_cooking` defaults have `fds_cooking_can = "no"` and `fds_cooking_cannot = "yes"`, which looks inverted relative to the question wording ("Do you have sufficient kitchen space and cooking equipment?") — needs confirmation before fixing