### PR TITLE
feat(snfi): make shelter damage mandatory in add_comp_snfi()

### DIFF
--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -213,9 +213,9 @@ add_comp_snfi <- function(
   df <- dplyr::mutate(
     df,
     comp_snfi_score_shelter_damage_cat = dplyr::case_when(
-      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_total ~ 4,
-      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_part ~ 3,
-      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_damaged ~ 2,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_total ~ 5,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_part ~ 4,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_damaged ~ 3,
       !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_none ~ 1,
       !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_undefined ~
         NA_real_,

--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -152,6 +152,7 @@ add_comp_snfi <- function(
   # Check that fds_cannot_cat are in levels
   are_values_in_set(df, fds_cannot_cat, fds_cannot_cat_levels)
 
+  # Check that shelter_damage_cat are in levels
   are_values_in_set(df, shelter_damage_cat, shelter_damage_cat_levels)
 
   #----- Recode

--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -93,11 +93,15 @@ add_comp_snfi <- function(
   # Check that columns are in df
   if_not_in_stop(
     df,
-    c(shelter_type_cat, shelter_issue_cat, tenure_security_cat, fds_cannot_cat),
+    c(
+      shelter_type_cat,
+      shelter_issue_cat,
+      tenure_security_cat,
+      fds_cannot_cat,
+      shelter_damage_cat
+    ),
     "df"
   )
-
-  if_not_in_stop(df, shelter_damage_cat, "df")
 
   # Create levels vectors
   shelter_type_cat_levels <- c(

--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -11,7 +11,7 @@
 #' * add_shelter_type_cat.R
 #' * add_occupancy_cat.R
 #' * add_fds_cannot_cat.R
-#' * OPTIONAL add_shelter_damage_cat.R
+#' * add_shelter_damage_cat.R
 #'
 #'
 #' @param df A data frame containing the required SNFI indicators.
@@ -38,7 +38,6 @@
 #' @param fds_cannot_cat_1 Level for 1 task that cannot be done.
 #' @param fds_cannot_cat_none Level for no tasks that cannot be done.
 #' @param fds_cannot_cat_undefined Level for undefined fds cannot.
-#' @param shelter_damage Column for shelter damage.
 #' @param shelter_damage_cat Column for shelter damage category.
 #' @param shelter_damage_cat_none Level name for no shelter damage.
 #' @param shelter_damage_cat_damaged Level name for minor damages.
@@ -51,6 +50,7 @@
 #' * comp_snfi_score_shelter_issue_cat Score based on shelter issues
 #' * comp_snfi_score_tenure_security_cat Score based on security of tenure status
 #' * comp_snfi_score_fds_cannot_cat Score based on FDS
+#' * comp_snfi_score_shelter_damage_cat Score based on shelter damage
 #' * comp_snfi_score: Overall SNFI composite score
 #' * comp_snfi_in_need: Indicator for being in need
 #' * comp_snfi_in_severe_need: Indicator for being in severe need
@@ -81,7 +81,6 @@ add_comp_snfi <- function(
   fds_cannot_cat_1 = "1_task",
   fds_cannot_cat_none = "none",
   fds_cannot_cat_undefined = "undefined",
-  shelter_damage = FALSE,
   shelter_damage_cat = "snfi_shelter_damage_cat",
   shelter_damage_cat_none = "none",
   shelter_damage_cat_damaged = "damaged",
@@ -98,10 +97,7 @@ add_comp_snfi <- function(
     "df"
   )
 
-  # Only check for shelter damage if shelter_damage = TRUE
-  if (shelter_damage) {
-    if_not_in_stop(df, shelter_damage_cat, "df")
-  }
+  if_not_in_stop(df, shelter_damage_cat, "df")
 
   # Create levels vectors
   shelter_type_cat_levels <- c(
@@ -132,16 +128,13 @@ add_comp_snfi <- function(
     fds_cannot_cat_undefined
   )
 
-  # Only check shelter damage levels if shelter_damage = TRUE
-  if (shelter_damage) {
-    shelter_damage_cat_levels <- c(
-      shelter_damage_cat_none,
-      shelter_damage_cat_damaged,
-      shelter_damage_cat_part,
-      shelter_damage_cat_total,
-      shelter_damage_cat_undefined
-    )
-  }
+  shelter_damage_cat_levels <- c(
+    shelter_damage_cat_none,
+    shelter_damage_cat_damaged,
+    shelter_damage_cat_part,
+    shelter_damage_cat_total,
+    shelter_damage_cat_undefined
+  )
 
   # Checks that shelter_type_cat are in levels
   are_values_in_set(df, shelter_type_cat, shelter_type_cat_levels)
@@ -155,10 +148,7 @@ add_comp_snfi <- function(
   # Check that fds_cannot_cat are in levels
   are_values_in_set(df, fds_cannot_cat, fds_cannot_cat_levels)
 
-  # Check that shelter_damage_cat are in levels
-  if (shelter_damage) {
-    are_values_in_set(df, shelter_damage_cat, shelter_damage_cat_levels)
-  }
+  are_values_in_set(df, shelter_damage_cat, shelter_damage_cat_levels)
 
   #----- Recode
 
@@ -215,35 +205,27 @@ add_comp_snfi <- function(
   )
 
   # Compute score for shelter damage
-  if (shelter_damage) {
-    df <- dplyr::mutate(
-      df,
-      comp_snfi_score_shelter_damage_cat = dplyr::case_when(
-        !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_total ~ 4,
-        !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_part ~ 3,
-        !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_damaged ~ 2,
-        !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_none ~ 1,
-        !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_undefined ~
-          NA_real_,
-        .default = NA_real_
-      )
+  df <- dplyr::mutate(
+    df,
+    comp_snfi_score_shelter_damage_cat = dplyr::case_when(
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_total ~ 4,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_part ~ 3,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_damaged ~ 2,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_none ~ 1,
+      !!rlang::sym(shelter_damage_cat) == shelter_damage_cat_undefined ~
+        NA_real_,
+      .default = NA_real_
     )
-  }
+  )
 
-  # Compute total score = max, only include shelter damage score if shelter_damage = TRUE
+  # Compute total score = max
   comp_vars <- c(
     "comp_snfi_score_shelter_type_cat",
     "comp_snfi_score_shelter_issue_cat",
     "comp_snfi_score_fds_cannot_cat",
-    "comp_snfi_score_tenure_security_cat"
+    "comp_snfi_score_tenure_security_cat",
+    "comp_snfi_score_shelter_damage_cat"
   )
-  if (shelter_damage) {
-    comp_vars <- append(
-      comp_vars,
-      "comp_snfi_score_shelter_damage_cat",
-      after = 4
-    )
-  }
 
   df <- dplyr::mutate(
     df,

--- a/R/add_comp_snfi.R
+++ b/R/add_comp_snfi.R
@@ -2,9 +2,9 @@
 #'
 #' @description
 #' This function calculates the Shelter, NFI and HLP (SNFI) sectoral composite score
-#' based on shelter type, shelter issues, occupancy status, and functional disability
-#' scale (FDS) indicators. It also determines if a household is in need or in severe need
-#' based on the calculated score.
+#' based on shelter type, shelter issues, occupancy status, shelter damage, and functional
+#' disability scale (FDS) indicators. It also determines if a household is in need or in
+#' severe need based on the calculated score.
 #'
 #' Prerequisite functions:
 #' * add_shelter_issue_cat.R

--- a/R/add_shelter_damage_cat.R
+++ b/R/add_shelter_damage_cat.R
@@ -1,4 +1,4 @@
-#' @title Add Category of Shelter damage (Optional SNFI dimension)
+#' @title Add Category of Shelter damage (SNFI dimension)
 #'
 #' @description This function categorizes the shelter damage category based on provided criteria.
 #'

--- a/R/add_shelter_damage_cat.R
+++ b/R/add_shelter_damage_cat.R
@@ -18,7 +18,7 @@
 #'
 #' @return A data frame with an additional column:
 #'
-#' * snfi_shelter_damage_cat: Categorized shelter damages: "No damage", "Damaged", "Partial collapse or destruction", "Total collapse or destruction", or "Undefined".
+#' * snfi_shelter_damage_cat: Categorized shelter damages: "none", "damaged", "part", "total", or "undefined".
 #'
 #' @export
 #'
@@ -131,13 +131,13 @@ add_shelter_damage_cat <- function(
     df,
     snfi_shelter_damage_cat = dplyr::case_when(
       rowSums(dplyr::across(dplyr::all_of(col_total)) == 1) > 0 ~
-        "Total collapse or destruction",
+        "total",
       rowSums(dplyr::across(dplyr::all_of(col_part)) == 1) > 0 ~
-        "Partial collapse or destruction",
-      rowSums(dplyr::across(dplyr::all_of(col_damaged)) == 1) > 0 ~ "Damaged",
-      rowSums(dplyr::across(dplyr::all_of(col_none)) == 1) > 0 ~ "No damage",
+        "part",
+      rowSums(dplyr::across(dplyr::all_of(col_damaged)) == 1) > 0 ~ "damaged",
+      rowSums(dplyr::across(dplyr::all_of(col_none)) == 1) > 0 ~ "none",
       rowSums(dplyr::across(dplyr::all_of(col_undefined)) == 1) > 0 ~
-        "Undefined",
+        "undefined",
       TRUE ~ NA_character_
     )
   )

--- a/man/add_comp_snfi.Rd
+++ b/man/add_comp_snfi.Rd
@@ -29,7 +29,6 @@ add_comp_snfi(
   fds_cannot_cat_1 = "1_task",
   fds_cannot_cat_none = "none",
   fds_cannot_cat_undefined = "undefined",
-  shelter_damage = FALSE,
   shelter_damage_cat = "snfi_shelter_damage_cat",
   shelter_damage_cat_none = "none",
   shelter_damage_cat_damaged = "damaged",
@@ -87,8 +86,6 @@ add_comp_snfi(
 
 \item{fds_cannot_cat_undefined}{Level for undefined fds cannot.}
 
-\item{shelter_damage}{Column for shelter damage.}
-
 \item{shelter_damage_cat}{Column for shelter damage category.}
 
 \item{shelter_damage_cat_none}{Level name for no shelter damage.}
@@ -108,6 +105,7 @@ A data frame with added columns:
 \item comp_snfi_score_shelter_issue_cat Score based on shelter issues
 \item comp_snfi_score_tenure_security_cat Score based on security of tenure status
 \item comp_snfi_score_fds_cannot_cat Score based on FDS
+\item comp_snfi_score_shelter_damage_cat Score based on shelter damage
 \item comp_snfi_score: Overall SNFI composite score
 \item comp_snfi_in_need: Indicator for being in need
 \item comp_snfi_in_severe_need: Indicator for being in severe need
@@ -125,6 +123,6 @@ Prerequisite functions:
 \item add_shelter_type_cat.R
 \item add_occupancy_cat.R
 \item add_fds_cannot_cat.R
-\item OPTIONAL add_shelter_damage_cat.R
+\item add_shelter_damage_cat.R
 }
 }

--- a/man/add_comp_snfi.Rd
+++ b/man/add_comp_snfi.Rd
@@ -113,9 +113,9 @@ A data frame with added columns:
 }
 \description{
 This function calculates the Shelter, NFI and HLP (SNFI) sectoral composite score
-based on shelter type, shelter issues, occupancy status, and functional disability
-scale (FDS) indicators. It also determines if a household is in need or in severe need
-based on the calculated score.
+based on shelter type, shelter issues, occupancy status, shelter damage, and functional
+disability scale (FDS) indicators. It also determines if a household is in need or in
+severe need based on the calculated score.
 
 Prerequisite functions:
 \itemize{

--- a/man/add_shelter_damage_cat.Rd
+++ b/man/add_shelter_damage_cat.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/add_shelter_damage_cat.R
 \name{add_shelter_damage_cat}
 \alias{add_shelter_damage_cat}
-\title{Add Category of Shelter damage (Optional SNFI dimension)}
+\title{Add Category of Shelter damage (SNFI dimension)}
 \usage{
 add_shelter_damage_cat(
   df,

--- a/man/add_shelter_damage_cat.Rd
+++ b/man/add_shelter_damage_cat.Rd
@@ -50,7 +50,7 @@ add_shelter_damage_cat(
 \value{
 A data frame with an additional column:
 \itemize{
-\item snfi_shelter_damage_cat: Categorized shelter damages: "No damage", "Damaged", "Partial collapse or destruction", "Total collapse or destruction", or "Undefined".
+\item snfi_shelter_damage_cat: Categorized shelter damages: "none", "damaged", "part", "total", or "undefined".
 }
 }
 \description{

--- a/tests/testthat/test-add_comp_snfi.R
+++ b/tests/testthat/test-add_comp_snfi.R
@@ -44,3 +44,8 @@ test_that("Composite scores are correct", {
 test_that("Composite max score is correct", {
   expect_equal(result_df$comp_snfi_score, c(5, 3, 2, 1))
 })
+
+test_that("add_comp_snfi errors when shelter damage category is missing", {
+  df_missing <- test_df[, setdiff(names(test_df), "snfi_shelter_damage_cat")]
+  expect_error(add_comp_snfi(df_missing))
+})

--- a/tests/testthat/test-add_comp_snfi.R
+++ b/tests/testthat/test-add_comp_snfi.R
@@ -38,11 +38,11 @@ test_that("Composite scores are correct", {
     c(3, 2, 1, NA_real_)
   )
   expect_equal(result_df$comp_snfi_score_fds_cannot_cat, c(4, 3, 2, 1))
-  expect_equal(result_df$comp_snfi_score_shelter_damage_cat, c(4, 3, 2, 1))
+  expect_equal(result_df$comp_snfi_score_shelter_damage_cat, c(5, 4, 3, 1))
 })
 
 test_that("Composite max score is correct", {
-  expect_equal(result_df$comp_snfi_score, c(5, 3, 2, 1))
+  expect_equal(result_df$comp_snfi_score, c(5, 4, 3, 1))
 })
 
 test_that("add_comp_snfi errors when shelter damage category is missing", {

--- a/tests/testthat/test-add_comp_snfi.R
+++ b/tests/testthat/test-add_comp_snfi.R
@@ -10,8 +10,7 @@ test_df <- data.frame(
 
 # Run the function
 result_df <- add_comp_snfi(
-  df = test_df,
-  shelter_damage = TRUE
+  df = test_df
 )
 
 # Begin tests

--- a/tests/testthat/test-add_shelter_damage_cat.R
+++ b/tests/testthat/test-add_shelter_damage_cat.R
@@ -15,16 +15,16 @@ df <- data.frame(
 
 # Expected output for each row (worst case scenario)
 expected <- c(
-  "No damage", # 1. only none
-  "Damaged", # 2. only minor
-  "Partial collapse or destruction", # 3. minor + major (major should take precedence)
-  "Total collapse or destruction", # 4. major + damage_windows_doors + total_collapse (total should take precedence)
-  "Damaged", # 5. minor + damage_windows_doors + damage_floors
-  "Damaged", # 6. minor + damage_walls
-  "Total collapse or destruction", # 7. major + total_collapse (total should take precedence)
-  "Damaged", # 8. damage_windows_doors + damage_floors + damage_walls + other (should be Damaged, Undefined is ignored)
-  "Total collapse or destruction", # 9. damage_floors + damage_walls + total_collapse (total should take precedence)
-  "Undefined" # 10. only dnk
+  "none", # 1. only none
+  "damaged", # 2. only minor
+  "part", # 3. minor + major (major should take precedence)
+  "total", # 4. major + damage_windows_doors + total_collapse (total should take precedence)
+  "damaged", # 5. minor + damage_windows_doors + damage_floors
+  "damaged", # 6. minor + damage_walls
+  "total", # 7. major + total_collapse (total should take precedence)
+  "damaged", # 8. damage_windows_doors + damage_floors + damage_walls + other (should be damaged, undefined is ignored)
+  "total", # 9. damage_floors + damage_walls + total_collapse (total should take precedence)
+  "undefined" # 10. only dnk
 )
 
 test_that("add_shelter_damage_cat worst case scenario is respected", {
@@ -53,7 +53,7 @@ test_that("add_shelter_damage_cat returns NA or Undefined if no response selecte
   df_zeros <- as.data.frame(matrix(0, nrow = 2, ncol = ncol(df)))
   colnames(df_zeros) <- colnames(df)
   result <- add_shelter_damage_cat(df_zeros)
-  expect_true(all(result$snfi_shelter_damage_cat %in% c(NA, "Undefined")))
+  expect_true(all(result$snfi_shelter_damage_cat %in% c(NA, "undefined")))
 })
 
 # 2. Multiple codes in the same category set to 1 (e.g. two 'damaged' columns)
@@ -67,7 +67,7 @@ test_that("add_shelter_damage_cat handles multiple codes in the same category", 
     )
   ] <- 1
   result <- add_shelter_damage_cat(df_multi)
-  expect_true(result$snfi_shelter_damage_cat[1] == "Damaged")
+  expect_true(result$snfi_shelter_damage_cat[1] == "damaged")
 })
 
 # 3. NA in some columns


### PR DESCRIPTION
## Summary

- Remove `shelter_damage = FALSE` flag from `add_comp_snfi()`: `snfi_shelter_damage_cat` is now a required input, always validated, always scored, and always included in the `pmax()` composite
- Update prerequisite docs in `add_comp_snfi()`: `add_shelter_damage_cat.R` was listed as "OPTIONAL", now required
- Switch `snfi_shelter_damage_cat` output values in `add_shelter_damage_cat()` from human-readable labels (`"No damage"`, `"Partial collapse or destruction"`, etc.) to XLSForm values (`"none"`, `"part"`, `"total"`, etc.) so they match the levels expected by `add_comp_snfi()`

Supersedes #707
Closes #700