### PR TITLE
feat(prot): update add_prot_score_movement to 2026 MSNI with new weights and severity bands

### DIFF
--- a/R/add_prot_score_movement.R
+++ b/R/add_prot_score_movement.R
@@ -109,7 +109,7 @@ add_prot_score_movement <- function(
       )
     )
 
-  # These columns need to result in an NA score for comp_prot_score_prot_needs_3
+  # These columns need to result in an NA score for comp_prot_score_movement
 
   dnk_col <- stringr::str_glue("{prot_needs_3_movement}{sep}{dnk}")
   pnta_col <- stringr::str_glue("{prot_needs_3_movement}{sep}{pnta}")

--- a/R/add_prot_score_movement.R
+++ b/R/add_prot_score_movement.R
@@ -118,9 +118,9 @@ add_prot_score_movement <- function(
   ) |>
     dplyr::mutate(
       comp_prot_score_movement = dplyr::case_when(
-        .data[["comp_prot_score_prot_needs_3"]] >= 4 ~ 4,
-        .data[["comp_prot_score_prot_needs_3"]] >= 2 ~ 3,
-        .data[["comp_prot_score_prot_needs_3"]] >= 1 ~ 2,
+        .data[["comp_prot_score_prot_needs_3"]] >= 3 ~ 4,
+        .data[["comp_prot_score_prot_needs_3"]] == 2 ~ 3,
+        .data[["comp_prot_score_prot_needs_3"]] == 1 ~ 2,
         .data[["comp_prot_score_prot_needs_3"]] == 0 ~ 1,
         TRUE ~ NA_real_
       )

--- a/R/add_prot_score_movement.R
+++ b/R/add_prot_score_movement.R
@@ -109,6 +109,14 @@ add_prot_score_movement <- function(
       )
     )
 
+  # These columns need to result in an NA score for comp_prot_score_prot_needs_3
+
+  dnk_col <- stringr::str_glue("{prot_needs_3_movement}{sep}{dnk}")
+  pnta_col <- stringr::str_glue("{prot_needs_3_movement}{sep}{pnta}")
+  other_safety_measures_col <- stringr::str_glue(
+    "{prot_needs_3_movement}{sep}{other_safety_measures}"
+  )
+
   # aggregate into composite scores
   weights_df <- sum_vars(
     weights_df,
@@ -126,11 +134,12 @@ add_prot_score_movement <- function(
       )
     ) |>
     dplyr::mutate(
-      comp_prot_score_movement = dplyr::if_else(
-        .data[[stringr::str_glue("{prot_needs_3_movement}{sep}{dnk}")]] == 1 |
-          .data[[stringr::str_glue("{prot_needs_3_movement}{sep}{pnta}")]] == 1,
-        NA_real_,
-        .data[["comp_prot_score_movement"]]
+      comp_prot_score_movement = dplyr::case_when(
+        .data[[dnk_col]] == 1 ~ NA_real_,
+        .data[[pnta_col]] == 1 ~ NA_real_,
+        .data[[other_safety_measures_col]] == 1 &
+          .data[["comp_prot_score_prot_needs_3"]] == 0 ~ NA_real_,
+        .default = .data[["comp_prot_score_movement"]]
       )
     )
 

--- a/R/add_prot_score_movement.R
+++ b/R/add_prot_score_movement.R
@@ -6,9 +6,11 @@
 #' @param no_changes_feel_unsafe answer option
 #' @param no_safety_concerns answer option
 #' @param women_girls_avoid_places answer option
-#' @param men_boys_avoid_places answer option
+#' @param men_avoid_places answer option
+#' @param boys_avoid_places answer option
 #' @param women_girls_avoid_night answer option
-#' @param men_boys_avoid_night answer option
+#' @param men_avoid_night answer option
+#' @param boys_avoid_night answer option
 #' @param girls_boys_avoid_school answer option
 #' @param different_routes answer option
 #' @param avoid_markets answer option
@@ -17,6 +19,8 @@
 #' @param other_safety_measures answer option
 #' @param dnk answer option
 #' @param pnta answer option
+#' @param men_avoid_places_weight Numeric weight for `men_avoid_places` (0–2). Default is 1.
+#' @param men_avoid_night_weight Numeric weight for `men_avoid_night` (0–2). Default is 1.
 #' @param .keep_weighted Logical, whether to keep the weighted columns in the output data frame. Default is FALSE.
 #'
 #' @return data frame with additional columns:
@@ -30,9 +34,11 @@ add_prot_score_movement <- function(
   no_changes_feel_unsafe = "no_changes_feel_unsafe",
   no_safety_concerns = "no_safety_concerns",
   women_girls_avoid_places = "women_girls_avoid_places",
-  men_boys_avoid_places = "men_boys_avoid_places",
+  men_avoid_places = "men_avoid_places",
+  boys_avoid_places = "boys_avoid_places",
   women_girls_avoid_night = "women_girls_avoid_night",
-  men_boys_avoid_night = "men_boys_avoid_night",
+  men_avoid_night = "men_avoid_night",
+  boys_avoid_night = "boys_avoid_night",
   girls_boys_avoid_school = "girls_boys_avoid_school",
   different_routes = "different_routes",
   avoid_markets = "avoid_markets",
@@ -41,21 +47,38 @@ add_prot_score_movement <- function(
   other_safety_measures = "other_safety_measures",
   dnk = "dnk",
   pnta = "pnta",
+  men_avoid_places_weight = 1,
+  men_avoid_night_weight = 1,
   .keep_weighted = FALSE
 ) {
   # capture all parameters
   params <- as.list(environment())
+
+  if (!checkmate::test_number(men_avoid_places_weight, lower = 0, upper = 2)) {
+    cli::cli_abort(
+      "{.arg men_avoid_places_weight} must be a single number between 0 and 2,
+       not {.val {men_avoid_places_weight}}."
+    )
+  }
+  if (!checkmate::test_number(men_avoid_night_weight, lower = 0, upper = 2)) {
+    cli::cli_abort(
+      "{.arg men_avoid_night_weight} must be a single number between 0 and 2,
+       not {.val {men_avoid_night_weight}}."
+    )
+  }
 
   # mapping of response → weight
   weights_mapping <- c(
     no_changes_feel_unsafe = 1,
     no_safety_concerns = 0,
     women_girls_avoid_places = 2,
-    men_boys_avoid_places = 2,
-    women_girls_avoid_night = 1,
-    men_boys_avoid_night = 1,
+    men_avoid_places = men_avoid_places_weight,
+    boys_avoid_places = 2,
+    women_girls_avoid_night = 2,
+    men_avoid_night = men_avoid_night_weight,
+    boys_avoid_night = 2,
     girls_boys_avoid_school = 2,
-    different_routes = 2,
+    different_routes = 1,
     avoid_markets = 2,
     avoid_public_offices = 2,
     avoid_fields = 2,
@@ -94,9 +117,12 @@ add_prot_score_movement <- function(
     na_rm = TRUE
   ) |>
     dplyr::mutate(
-      comp_prot_score_movement = pmin(
-        .data[["comp_prot_score_prot_needs_3"]] + 1,
-        4
+      comp_prot_score_movement = dplyr::case_when(
+        .data[["comp_prot_score_prot_needs_3"]] >= 4 ~ 4,
+        .data[["comp_prot_score_prot_needs_3"]] >= 2 ~ 3,
+        .data[["comp_prot_score_prot_needs_3"]] >= 1 ~ 2,
+        .data[["comp_prot_score_prot_needs_3"]] == 0 ~ 1,
+        TRUE ~ NA_real_
       )
     ) |>
     dplyr::mutate(

--- a/man/add_prot_score_movement.Rd
+++ b/man/add_prot_score_movement.Rd
@@ -11,9 +11,11 @@ add_prot_score_movement(
   no_changes_feel_unsafe = "no_changes_feel_unsafe",
   no_safety_concerns = "no_safety_concerns",
   women_girls_avoid_places = "women_girls_avoid_places",
-  men_boys_avoid_places = "men_boys_avoid_places",
+  men_avoid_places = "men_avoid_places",
+  boys_avoid_places = "boys_avoid_places",
   women_girls_avoid_night = "women_girls_avoid_night",
-  men_boys_avoid_night = "men_boys_avoid_night",
+  men_avoid_night = "men_avoid_night",
+  boys_avoid_night = "boys_avoid_night",
   girls_boys_avoid_school = "girls_boys_avoid_school",
   different_routes = "different_routes",
   avoid_markets = "avoid_markets",
@@ -22,6 +24,8 @@ add_prot_score_movement(
   other_safety_measures = "other_safety_measures",
   dnk = "dnk",
   pnta = "pnta",
+  men_avoid_places_weight = 1,
+  men_avoid_night_weight = 1,
   .keep_weighted = FALSE
 )
 }
@@ -38,11 +42,15 @@ add_prot_score_movement(
 
 \item{women_girls_avoid_places}{answer option}
 
-\item{men_boys_avoid_places}{answer option}
+\item{men_avoid_places}{answer option}
+
+\item{boys_avoid_places}{answer option}
 
 \item{women_girls_avoid_night}{answer option}
 
-\item{men_boys_avoid_night}{answer option}
+\item{men_avoid_night}{answer option}
+
+\item{boys_avoid_night}{answer option}
 
 \item{girls_boys_avoid_school}{answer option}
 
@@ -59,6 +67,10 @@ add_prot_score_movement(
 \item{dnk}{answer option}
 
 \item{pnta}{answer option}
+
+\item{men_avoid_places_weight}{Numeric weight for \code{men_avoid_places} (0–2). Default is 1.}
+
+\item{men_avoid_night_weight}{Numeric weight for \code{men_avoid_night} (0–2). Default is 1.}
 
 \item{.keep_weighted}{Logical, whether to keep the weighted columns in the output data frame. Default is FALSE.}
 }

--- a/tests/testthat/test-add_prot_score_movement.R
+++ b/tests/testthat/test-add_prot_score_movement.R
@@ -187,3 +187,20 @@ test_that("weight parameters are validated", {
     "must be a single number between 0 and 2"
   )
 })
+
+test_that("score is NA when only other_safety_measures is selected", {
+  edge_case <- dummy_df |>
+    dplyr::filter(tot == 1, `prot_needs_3_movement/other_safety_measures` == 1)
+
+  res <- add_prot_score_movement(edge_case)
+
+  expect_true(all(is.na(res$comp_prot_score_movement)))
+
+  # when co existing with another option the score should not be NA (cannot be with pnta or dnk anyway)
+  edge_case <- dummy_df |>
+    dplyr::filter(tot == 2, `prot_needs_3_movement/other_safety_measures` == 1)
+
+  res <- add_prot_score_movement(edge_case)
+
+  expect_false(any(is.na(res$comp_prot_score_movement)))
+})

--- a/tests/testthat/test-add_prot_score_movement.R
+++ b/tests/testthat/test-add_prot_score_movement.R
@@ -204,3 +204,20 @@ test_that("score is NA when only other_safety_measures is selected", {
 
   expect_false(any(is.na(res$comp_prot_score_movement)))
 })
+
+
+test_that("score is not affected by `other_safety_measures` if not only selection", {
+  edge_case <- dummy_df |>
+    dplyr::filter(tot > 1, `prot_needs_3_movement/other_safety_measures` == 1)
+
+  res <- add_prot_score_movement(edge_case)
+  edge_case2 <- edge_case |>
+    dplyr::mutate(`prot_needs_3_movement/other_safety_measures` = 0)
+
+  res2 <- add_prot_score_movement(edge_case2)
+  score_cols <- c("comp_prot_score_prot_needs_3", "comp_prot_score_movement")
+  expect_equal(
+    dplyr::select(res, dplyr::all_of(score_cols)),
+    dplyr::select(res2, dplyr::all_of(score_cols))
+  )
+})

--- a/tests/testthat/test-add_prot_score_movement.R
+++ b/tests/testthat/test-add_prot_score_movement.R
@@ -119,14 +119,13 @@ test_that("scoring thresholds are correct", {
 
   sum_0 <- non_flagged$comp_prot_score_prot_needs_3 == 0
   sum_1 <- non_flagged$comp_prot_score_prot_needs_3 == 1
-  sum_2_3 <- non_flagged$comp_prot_score_prot_needs_3 >= 2 &
-    non_flagged$comp_prot_score_prot_needs_3 < 4
-  sum_4plus <- non_flagged$comp_prot_score_prot_needs_3 >= 4
+  sum_2 <- non_flagged$comp_prot_score_prot_needs_3 == 2
+  sum_3plus <- non_flagged$comp_prot_score_prot_needs_3 >= 3
 
   expect_true(all(non_flagged$comp_prot_score_movement[sum_0] == 1))
   expect_true(all(non_flagged$comp_prot_score_movement[sum_1] == 2))
-  expect_true(all(non_flagged$comp_prot_score_movement[sum_2_3] == 3))
-  expect_true(all(non_flagged$comp_prot_score_movement[sum_4plus] == 4))
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_2] == 3))
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_3plus] == 4))
 })
 
 test_that("flexible weights are applied correctly", {

--- a/tests/testthat/test-add_prot_score_movement.R
+++ b/tests/testthat/test-add_prot_score_movement.R
@@ -4,9 +4,11 @@ dummy_df <- generate_survey_choice_combinations(
     "no_changes_feel_unsafe",
     "no_safety_concerns",
     "women_girls_avoid_places",
-    "men_boys_avoid_places",
+    "men_avoid_places",
+    "boys_avoid_places",
     "women_girls_avoid_night",
-    "men_boys_avoid_night",
+    "men_avoid_night",
+    "boys_avoid_night",
     "girls_boys_avoid_school",
     "different_routes",
     "avoid_markets",
@@ -56,9 +58,11 @@ test_that("._keep_weighted controls whether _w columns appear", {
     "no_changes_feel_unsafe",
     "no_safety_concerns",
     "women_girls_avoid_places",
-    "men_boys_avoid_places",
+    "men_avoid_places",
+    "boys_avoid_places",
     "women_girls_avoid_night",
-    "men_boys_avoid_night",
+    "men_avoid_night",
+    "boys_avoid_night",
     "girls_boys_avoid_school",
     "different_routes",
     "avoid_markets",
@@ -100,4 +104,87 @@ test_that("composite value calculated correctly and NA for dnk/pnta rows", {
   expect_true(all(res$comp_prot_score_movement[good_rows] <= 4, na.rm = TRUE))
 
   expect_true(all(is.na(res$comp_prot_score_movement[flagged])))
+})
+
+test_that("scoring thresholds are correct", {
+  res <- add_prot_score_movement(dummy_df, .keep_weighted = TRUE)
+
+  # For rows with a known raw sum, verify the composite score
+  # sum = 0 then comp_prot_score_movement = 1
+  # sum = 1 then comp_prot_score_movement = 2
+  # sum >= 2 and < 4 then comp_prot_score_movement = 3
+  # sum >= 4 then comp_prot_score_movement = 4
+
+  non_flagged <- res[!is.na(res$comp_prot_score_movement), ]
+
+  sum_0 <- non_flagged$comp_prot_score_prot_needs_3 == 0
+  sum_1 <- non_flagged$comp_prot_score_prot_needs_3 == 1
+  sum_2_3 <- non_flagged$comp_prot_score_prot_needs_3 >= 2 &
+    non_flagged$comp_prot_score_prot_needs_3 < 4
+  sum_4plus <- non_flagged$comp_prot_score_prot_needs_3 >= 4
+
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_0] == 1))
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_1] == 2))
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_2_3] == 3))
+  expect_true(all(non_flagged$comp_prot_score_movement[sum_4plus] == 4))
+})
+
+test_that("flexible weights are applied correctly", {
+  # default weights
+  res_def <- add_prot_score_movement(dummy_df, .keep_weighted = TRUE)
+  # men_avoid_places default weight is 1
+  expect_equal(
+    max(res_def$`prot_needs_3_movement/men_avoid_places_w`, na.rm = TRUE),
+    1
+  )
+  # boys_avoid_places weight is 2 (not flexible)
+  expect_equal(
+    max(res_def$`prot_needs_3_movement/boys_avoid_places_w`, na.rm = TRUE),
+    2
+  )
+  # men_avoid_night default weight is 1
+  expect_equal(
+    max(res_def$`prot_needs_3_movement/men_avoid_night_w`, na.rm = TRUE),
+    1
+  )
+  # boys_avoid_night weight is 2 (not flexible)
+  expect_equal(
+    max(res_def$`prot_needs_3_movement/boys_avoid_night_w`, na.rm = TRUE),
+    2
+  )
+
+  # override weights
+  res_ov <- add_prot_score_movement(
+    dummy_df,
+    men_avoid_places_weight = 0,
+    men_avoid_night_weight = 2,
+    .keep_weighted = TRUE
+  )
+  expect_equal(
+    max(res_ov$`prot_needs_3_movement/men_avoid_places_w`, na.rm = TRUE),
+    0
+  )
+  expect_equal(
+    max(res_ov$`prot_needs_3_movement/men_avoid_night_w`, na.rm = TRUE),
+    2
+  )
+})
+
+test_that("weight parameters are validated", {
+  expect_error(
+    add_prot_score_movement(dummy_df, men_avoid_places_weight = 3),
+    "must be a single number between 0 and 2"
+  )
+  expect_error(
+    add_prot_score_movement(dummy_df, men_avoid_places_weight = -1),
+    "must be a single number between 0 and 2"
+  )
+  expect_error(
+    add_prot_score_movement(dummy_df, men_avoid_night_weight = 3),
+    "must be a single number between 0 and 2"
+  )
+  expect_error(
+    add_prot_score_movement(dummy_df, men_avoid_night_weight = "a"),
+    "must be a single number between 0 and 2"
+  )
 })

--- a/tests/testthat/test-add_prot_score_movement.R
+++ b/tests/testthat/test-add_prot_score_movement.R
@@ -112,8 +112,8 @@ test_that("scoring thresholds are correct", {
   # For rows with a known raw sum, verify the composite score
   # sum = 0 then comp_prot_score_movement = 1
   # sum = 1 then comp_prot_score_movement = 2
-  # sum >= 2 and < 4 then comp_prot_score_movement = 3
-  # sum >= 4 then comp_prot_score_movement = 4
+  # sum = 2 then comp_prot_score_movement = 3
+  # sum >= 3 then comp_prot_score_movement = 4
 
   non_flagged <- res[!is.na(res$comp_prot_score_movement), ]
 


### PR DESCRIPTION
## Summary

- Splits `men_boys_avoid_places` into `men_avoid_places` and `boys_avoid_places`, and `men_boys_avoid_night` into `men_avoid_night` and `boys_avoid_night`
- Adds `men_avoid_places_weight` and `men_avoid_night_weight` params (default 1, range 0–2), validated via `checkmate::test_number()` with `cli::cli_abort()` for error reporting
- Updates fixed weights: `women_girls_avoid_night` 1→2, `different_routes` 2→1
- Replaces `pmin(sum + 1, 4)` with `case_when` for `comp_prot_score_movement`: sum 0→1, 1→2, 2→3, ≥3→4

> **Note:** Issue #704's threshold wording was superseded during review — per @mario-fidalgo's confirmation with Guillaume P. (since severity bands 3 and 4 overlapped in the original MSNI FW wording), the final agreed mapping is: 0→1, 1→2, 2→3, ≥3→4.

- **Out of scope of #704:** fixes `comp_prot_score_movement` returning a score of 1 (instead of `NA`) when `other_safety_measures` is the only option selected, per QuentinVillotta's review comment.

Closes #704
Supersedes #706
