### PR TITLE
feat: 2026 WASH scoring update for add_comp_wash

### DIFF
--- a/R/add_comp_wash.R
+++ b/R/add_comp_wash.R
@@ -250,19 +250,19 @@ add_comp_wash <- function(
       !!rlang::sym(setting) == setting_camp &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           drinking_water_quality_jmp_cat_surface_water ~
-        5,
-      !!rlang::sym(setting) == setting_camp &
-        !!rlang::sym(drinking_water_quality_jmp_cat) %in%
-          drinking_water_quality_jmp_cat_unimproved ~
         4,
       !!rlang::sym(setting) == setting_camp &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
-          drinking_water_quality_jmp_cat_limited ~
+          drinking_water_quality_jmp_cat_unimproved ~
         3,
       !!rlang::sym(setting) == setting_camp &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
-          drinking_water_quality_jmp_cat_basic ~
+          drinking_water_quality_jmp_cat_limited ~
         2,
+      !!rlang::sym(setting) == setting_camp &
+        !!rlang::sym(drinking_water_quality_jmp_cat) %in%
+          drinking_water_quality_jmp_cat_basic ~
+        1,
       !!rlang::sym(setting) == setting_camp &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           drinking_water_quality_jmp_cat_undefined ~
@@ -280,9 +280,14 @@ add_comp_wash <- function(
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           c(
             drinking_water_quality_jmp_cat_limited,
-            drinking_water_quality_jmp_cat_basic
           ) ~
         2,
+      !!rlang::sym(setting) == setting_urban &
+        !!rlang::sym(drinking_water_quality_jmp_cat) %in%
+          c(
+            drinking_water_quality_jmp_cat_basic # Grouped with safely managed, which is set to 1 at the begnning of the conditional branch
+          ) ~
+        1,
       !!rlang::sym(setting) == setting_urban &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           drinking_water_quality_jmp_cat_undefined ~
@@ -295,10 +300,15 @@ add_comp_wash <- function(
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           c(
-            drinking_water_quality_jmp_cat_unimproved,
             drinking_water_quality_jmp_cat_limited
           ) ~
         2,
+      !!rlang::sym(setting) == setting_rural &
+        !!rlang::sym(drinking_water_quality_jmp_cat) %in%
+          c(
+            drinking_water_quality_jmp_cat_unimproved,
+          ) ~
+        3,
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           drinking_water_quality_jmp_cat_basic ~
@@ -399,7 +409,7 @@ add_comp_wash <- function(
         !!rlang::sym(sanitation_facility_cat) == sanitation_facility_cat_none &
         !!rlang::sym(sanitation_facility_jmp_cat) ==
           sanitation_facility_jmp_cat_open_defecation ~
-        4,
+        3,
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(sanitation_facility_jmp_cat) %in%
           c(

--- a/R/add_comp_wash.R
+++ b/R/add_comp_wash.R
@@ -279,7 +279,7 @@ add_comp_wash <- function(
       !!rlang::sym(setting) == setting_urban &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           c(
-            drinking_water_quality_jmp_cat_limited,
+            drinking_water_quality_jmp_cat_limited
           ) ~
         2,
       !!rlang::sym(setting) == setting_urban &
@@ -306,7 +306,7 @@ add_comp_wash <- function(
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(drinking_water_quality_jmp_cat) %in%
           c(
-            drinking_water_quality_jmp_cat_unimproved,
+            drinking_water_quality_jmp_cat_unimproved
           ) ~
         3,
       !!rlang::sym(setting) == setting_rural &

--- a/R/add_comp_wash.R
+++ b/R/add_comp_wash.R
@@ -131,6 +131,7 @@ add_comp_wash <- function(
       sanitation_facility_jmp_cat,
       sanitation_facility_cat,
       sanitation_facility_n_ind,
+      sharing_sanitation_facility_cat,
       handwashing_facility_jmp_cat
     ),
     "df"

--- a/R/add_comp_wash.R
+++ b/R/add_comp_wash.R
@@ -41,7 +41,6 @@
 #' @param sanitation_facility_jmp_cat_unimproved Value for "unimproved" in sanitation facility JMP category.
 #' @param sanitation_facility_jmp_cat_limited Value for "limited" in sanitation facility JMP category.
 #' @param sanitation_facility_jmp_cat_basic Value for "basic" in sanitation facility JMP category.
-#' @param sanitation_facility_jmp_cat_safely_managed Value for "safely managed" in sanitation facility JMP category.
 #' @param sanitation_facility_jmp_cat_undefined Value for "undefined" in sanitation facility JMP category.
 #' @param sanitation_facility_cat Column name for sanitation facility category.
 #' @param sanitation_facility_cat_none Value for "none" in sanitation facility category.
@@ -99,7 +98,6 @@ add_comp_wash <- function(
   sanitation_facility_jmp_cat_unimproved = "unimproved",
   sanitation_facility_jmp_cat_limited = "limited",
   sanitation_facility_jmp_cat_basic = "basic",
-  sanitation_facility_jmp_cat_safely_managed = "safely_managed",
   sanitation_facility_jmp_cat_undefined = "undefined",
   sanitation_facility_cat = "wash_sanitation_facility_cat",
   sanitation_facility_cat_none = "none",
@@ -173,7 +171,6 @@ add_comp_wash <- function(
       sanitation_facility_jmp_cat_unimproved,
       sanitation_facility_jmp_cat_limited,
       sanitation_facility_jmp_cat_basic,
-      sanitation_facility_jmp_cat_safely_managed,
       sanitation_facility_jmp_cat_undefined
     )
   )
@@ -395,10 +392,7 @@ add_comp_wash <- function(
         2,
       !!rlang::sym(setting) == setting_urban &
         !!rlang::sym(sanitation_facility_jmp_cat) %in%
-          c(
-            sanitation_facility_jmp_cat_safely_managed,
-            sanitation_facility_jmp_cat_basic
-          ) ~
+          sanitation_facility_jmp_cat_basic ~
         1,
       !!rlang::sym(setting) == setting_urban &
         !!rlang::sym(sanitation_facility_jmp_cat) ==
@@ -419,10 +413,7 @@ add_comp_wash <- function(
         2,
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(sanitation_facility_jmp_cat) %in%
-          c(
-            sanitation_facility_jmp_cat_basic,
-            sanitation_facility_jmp_cat_safely_managed
-          ) ~
+          sanitation_facility_jmp_cat_basic ~
         1,
       !!rlang::sym(setting) == setting_rural &
         !!rlang::sym(sanitation_facility_jmp_cat) ==

--- a/R/add_drinking_water_source_cat.R
+++ b/R/add_drinking_water_source_cat.R
@@ -313,7 +313,6 @@ add_drinking_water_quality_jmp_cat <- function(
     df,
     drinking_water_time_30min_cat,
     c(
-      drinking_water_time_30min_cat,
       drinking_water_time_30min_cat_premises,
       drinking_water_time_30min_cat_under_30min,
       drinking_water_time_30min_cat_above_30min,

--- a/man/add_comp_wash.Rd
+++ b/man/add_comp_wash.Rd
@@ -30,7 +30,6 @@ add_comp_wash(
   sanitation_facility_jmp_cat_unimproved = "unimproved",
   sanitation_facility_jmp_cat_limited = "limited",
   sanitation_facility_jmp_cat_basic = "basic",
-  sanitation_facility_jmp_cat_safely_managed = "safely_managed",
   sanitation_facility_jmp_cat_undefined = "undefined",
   sanitation_facility_cat = "wash_sanitation_facility_cat",
   sanitation_facility_cat_none = "none",
@@ -103,8 +102,6 @@ add_comp_wash(
 \item{sanitation_facility_jmp_cat_limited}{Value for "limited" in sanitation facility JMP category.}
 
 \item{sanitation_facility_jmp_cat_basic}{Value for "basic" in sanitation facility JMP category.}
-
-\item{sanitation_facility_jmp_cat_safely_managed}{Value for "safely managed" in sanitation facility JMP category.}
 
 \item{sanitation_facility_jmp_cat_undefined}{Value for "undefined" in sanitation facility JMP category.}
 

--- a/tests/testthat/test-add_comp_wash.R
+++ b/tests/testthat/test-add_comp_wash.R
@@ -149,7 +149,7 @@ undefined_water_quantity_data <- data.frame(
     "basic",
     "limited",
     "unimproved",
-    "safely_managed"
+    "basic"
   ),
   wash_sanitation_facility_cat = c(
     "improved",

--- a/tests/testthat/test-add_comp_wash.R
+++ b/tests/testthat/test-add_comp_wash.R
@@ -59,7 +59,7 @@ test_that("Drinking water quality scoring works based on setting", {
     drinking_water_quality_jmp_cat_undefined = "undefined"
   )
 
-  expected_result <- c(5, 3, 2) # Surface water (camp) -> 5, Unimproved (urban) -> 3, Limited (rural) -> 2
+  expected_result <- c(4, 3, 2) # Surface water (camp) -> 4, Unimproved (urban) -> 3, Limited (rural) -> 2
 
   expect_equal(df_result$comp_wash_score_water_quality, expected_result)
 })
@@ -180,6 +180,45 @@ undefined_water_quantity_data <- data.frame(
 test_that("Function handles undefined water quantity correctly", {
   result <- add_comp_wash(undefined_water_quantity_data)
   expect_equal(result$comp_wash_score_water_quantity, c(NA, NA, 1, 5))
+})
+
+# Test data for 2026 new logic verification
+new_logic_data <- data.frame(
+  setting = c("camp", "camp", "camp", "urban", "rural", "rural"),
+  wash_hwise_drink = rep("always", 6),
+  wash_drinking_water_quality_jmp_cat = c(
+    "basic",
+    "limited",
+    "unimproved",
+    "basic",
+    "unimproved",
+    "safely_managed"
+  ),
+  wash_sanitation_facility_jmp_cat = c(
+    rep("basic", 5),
+    "open_defecation"
+  ),
+  wash_sanitation_facility_cat = c(
+    rep("improved", 5),
+    "none"
+  ),
+  wash_sharing_sanitation_facility_n_ind = rep("19_and_below", 6),
+  wash_sharing_sanitation_facility_cat = rep("not_shared", 6),
+  wash_handwashing_facility_jmp_cat = rep("basic", 6)
+)
+
+test_that("Water quality 2026 new logic is correctly implemented", {
+  result <- add_comp_wash(new_logic_data)
+
+  expected <- c(1, 2, 3, 1, 3, 1)
+
+  expect_equal(result$comp_wash_score_water_quality, expected)
+})
+
+test_that("Rural sanitation open_defecation 2026 new logic is correctly implemented", {
+  result <- add_comp_wash(new_logic_data)
+
+  expect_equal(result$comp_wash_score_sanitation[6], 3)
 })
 
 # Test with invalid sanitation facility categories


### PR DESCRIPTION
## Summary
Updates `add_comp_wash()` water quality and sanitation scoring logic to align
with the 2026 MSNI Framework.

**Closes #703**

### Water quality — Camp
Severity scale compressed from 5 to 4 levels:
- surface_water: 5 → 4
- unimproved: 4 → 3
- limited: 3 → 2
- basic: 2 → 1

### Water quality — Urban
- basic moved from score 2 → 1 (grouped with safely_managed)

### Water quality — Rural
- unimproved moved from score 2 → 3

### Sanitation — Rural
- open_defecation moved from score 4 → 3

## Tests
- Updated expectation for camp + surface_water (5 → 4)
- Added targeted tests covering all new logic pathways