### PR TITLE
feat(edu): add child_pregnancy to add_loop_edu_barrier_protection_d

### DIFF
--- a/R/add_loop_edu_barrier_protection_d.R
+++ b/R/add_loop_edu_barrier_protection_d.R
@@ -28,6 +28,7 @@ add_loop_edu_barrier_protection_d <- function(
     "child_work_outside",
     "child_armed_group",
     "child_marriage",
+    "child_pregnancy",
     "ban",
     "enroll_lack_documentation",
     "discrimination"

--- a/man/add_loop_edu_barrier_protection_d.Rd
+++ b/man/add_loop_edu_barrier_protection_d.Rd
@@ -10,7 +10,7 @@ add_loop_edu_barrier_protection_d(
   barriers = "edu_barrier",
   protection_issues = c("protection_at_school", "protection_travel_school",
     "child_work_home", "child_work_outside", "child_armed_group", "child_marriage",
-    "ban", "enroll_lack_documentation", "discrimination"),
+    "child_pregnancy", "ban", "enroll_lack_documentation", "discrimination"),
   ind_schooling_age_d = "edu_ind_schooling_age_d"
 )
 

--- a/tests/testthat/test-add_loop_edu_barrier_protection_d.R
+++ b/tests/testthat/test-add_loop_edu_barrier_protection_d.R
@@ -89,3 +89,16 @@ test_that("add_loop_edu_barrier_protection_d function handles edge cases", {
   expect_equal(result$edu_ind_barrier_protection_d[1], 0)
   expect_equal(result$edu_ind_barrier_protection_d[2], 0)
 })
+
+# 8. Test that child_pregnancy is recognized as a protection barrier
+child_pregnancy_data <- data.frame(
+  uuid = c(1, 2),
+  edu_barrier = c("child_pregnancy", "other"),
+  edu_ind_schooling_age_d = c(1, 1)
+)
+
+test_that("add_loop_edu_barrier_protection_d function flags child_pregnancy as a barrier", {
+  result <- add_loop_edu_barrier_protection_d(child_pregnancy_data)
+  expect_equal(result$edu_ind_barrier_protection_d[1], 1)
+  expect_equal(result$edu_ind_barrier_protection_d[2], 0)
+})


### PR DESCRIPTION
## Summary

- Add `child_pregnancy` to the default `protection_issues` list in `add_loop_edu_barrier_protection_d()`, so it's recognized as a child-protection barrier to education alongside the existing codes
- Add a regression test covering the new option

Closes #730
