### PR TITLE
refactor(wash): update add_drinking_water_source_cat default values to match updated form

### DIFF
--- a/R/add_drinking_water_source_cat.R
+++ b/R/add_drinking_water_source_cat.R
@@ -29,7 +29,7 @@ add_drinking_water_source_cat <- function(
     "tap",
     "borehole",
     "protected_well",
-    "protected_spring",
+    "well_spring",
     "rainwater_collection",
     "tank_truck",
     "cart_tank",

--- a/man/add_drinking_water_source_cat.Rd
+++ b/man/add_drinking_water_source_cat.Rd
@@ -11,7 +11,7 @@ add_drinking_water_source_cat(
   df,
   drinking_water_source = "wash_drinking_water_source",
   drinking_water_source_cat_improved = c("piped_dwelling", "piped_compound",
-    "piped_neighbour", "tap", "borehole", "protected_well", "protected_spring",
+    "piped_neighbour", "tap", "borehole", "protected_well", "well_spring",
     "rainwater_collection", "tank_truck", "cart_tank", "kiosk", "bottled_water",
     "sachet_water"),
   drinking_water_source_cat_unimproved = c("unprotected_well", "unprotected_spring"),

--- a/tests/testthat/test-add_drinking_water_source_cat.R
+++ b/tests/testthat/test-add_drinking_water_source_cat.R
@@ -90,6 +90,37 @@ test_that("add_drinking_water_source_cat handles undefined drinking water source
   expect_equal(unique(result$wash_drinking_water_source_cat), "undefined")
 })
 
+test_that("add_drinking_water_source_cat recodes improved sources correctly", {
+  improved_sources <- dplyr::tibble(
+    wash_drinking_water_source = c(
+      "piped_dwelling",
+      "piped_compound",
+      "piped_neighbour",
+      "tap",
+      "borehole",
+      "protected_well",
+      "well_spring",
+      "rainwater_collection",
+      "tank_truck",
+      "cart_tank",
+      "kiosk",
+      "bottled_water",
+      "sachet_water"
+    )
+  )
+  result <- add_drinking_water_source_cat(improved_sources)
+  expect_setequal(
+    result$wash_drinking_water_source_cat,
+    rep("improved", nrow(improved_sources))
+  )
+})
+
+test_that("add_drinking_water_source_cat errors on unknown source value", {
+  df_unknown <- dummy_data |>
+    dplyr::mutate(wash_drinking_water_source = "protected_spring")
+  expect_error(add_drinking_water_source_cat(df_unknown), class = "error")
+})
+
 test_that("add_drinking_water_time_cat errors on invalid integer values", {
   df_invalid <- dummy_data
   df_invalid$wash_drinking_water_time_int[2] <- -5


### PR DESCRIPTION
## Summary

- Replace `protected_spring` with `well_spring` in the default `drinking_water_source_cat_improved` list of `add_drinking_water_source_cat()`, matching the current XLSForm choices
- Add tests covering the full improved-sources list (incl. `well_spring`) and confirming the old `protected_spring` value now errors as unknown

Closes #719
