### PR TITLE
refactor(wash): update add_drinking_water_time_cat default values to match updated form

### DIFF
--- a/R/add_drinking_water_source_cat.R
+++ b/R/add_drinking_water_source_cat.R
@@ -96,7 +96,8 @@ add_drinking_water_source_cat <- function(
 #' @param drinking_water_time_int Component column: Time to fetch water, integer.
 #' @param max Integer, the maximum value for the time to fetch water.
 #' @param drinking_water_time_sl Component column: Time to fetch water, simple choice.
-#' @param sl_under_30_min Response code for under 30 minutes.
+#' @param sl_under_30_min Response code for under 30 minutes. Must be one of
+#' c("5min_or_less", "5min_15min", "15min_30min").
 #' @param sl_30min_1hr Response code for 30 minutes to 1 hour.
 #' @param sl_more_than_1hr Response code for more than 1 hour.
 #' @param sl_undefined Character vector of responses codes for undefined information, e.g. "Don't know" or "Prefer not to answer".
@@ -108,14 +109,14 @@ add_drinking_water_source_cat <- function(
 add_drinking_water_time_cat <- function(
   df,
   drinking_water_time_yn = "wash_drinking_water_time_yn",
-  water_on_premises = "water_on_premises",
+  water_on_premises = c("water_in_dwelling", "water_in_plot"),
   number_minutes = "number_minutes",
   dnk = "dnk",
   undefined = "pnta",
   drinking_water_time_int = "wash_drinking_water_time_int",
   max = 600,
   drinking_water_time_sl = "wash_drinking_water_time_sl",
-  sl_under_30_min = "under_30_min",
+  sl_under_30_min = c("5min_or_less", "5min_15min", "15min_30min"),
   sl_30min_1hr = "30min_1hr",
   sl_more_than_1hr = "more_than_1hr",
   sl_undefined = c("dnk", "pnta"),
@@ -146,6 +147,11 @@ add_drinking_water_time_cat <- function(
     drinking_water_time_yn,
     c(water_on_premises, number_minutes, dnk, undefined)
   )
+
+  sl_under_30_min <- match.arg(
+    sl_under_30_min
+  )
+
   are_values_in_set(
     df,
     drinking_water_time_sl,

--- a/man/add_drinking_water_source_cat.Rd
+++ b/man/add_drinking_water_source_cat.Rd
@@ -22,14 +22,14 @@ add_drinking_water_source_cat(
 add_drinking_water_time_cat(
   df,
   drinking_water_time_yn = "wash_drinking_water_time_yn",
-  water_on_premises = "water_on_premises",
+  water_on_premises = c("water_in_dwelling", "water_in_plot"),
   number_minutes = "number_minutes",
   dnk = "dnk",
   undefined = "pnta",
   drinking_water_time_int = "wash_drinking_water_time_int",
   max = 600,
   drinking_water_time_sl = "wash_drinking_water_time_sl",
-  sl_under_30_min = "under_30_min",
+  sl_under_30_min = c("5min_or_less", "5min_15min", "15min_30min"),
   sl_30min_1hr = "30min_1hr",
   sl_more_than_1hr = "more_than_1hr",
   sl_undefined = c("dnk", "pnta"),
@@ -90,7 +90,8 @@ add_drinking_water_quality_jmp_cat(
 
 \item{drinking_water_time_sl}{Component column: Time to fetch water, simple choice.}
 
-\item{sl_under_30_min}{Response code for under 30 minutes.}
+\item{sl_under_30_min}{Response code for under 30 minutes. Must be one of
+c("5min_or_less", "5min_15min", "15min_30min").}
 
 \item{sl_30min_1hr}{Response code for 30 minutes to 1 hour.}
 

--- a/tests/testthat/test-add_drinking_water_source_cat.R
+++ b/tests/testthat/test-add_drinking_water_source_cat.R
@@ -45,7 +45,7 @@ dummy_data <- dplyr::tibble(
     "other"
   ),
   wash_drinking_water_time_yn = c(
-    "water_on_premises",
+    "water_in_plot",
     "number_minutes",
     "dnk",
     "pnta"
@@ -53,7 +53,7 @@ dummy_data <- dplyr::tibble(
   wash_drinking_water_time_int = c(NA, 45, 70, 20),
   wash_drinking_water_time_sl = c(
     NA,
-    "under_30_min",
+    "5min_or_less",
     "30min_1hr",
     "more_than_1hr"
   )
@@ -73,6 +73,22 @@ test_that("add_drinking_water_source_cat returns expected column and covers all 
 test_that("add_drinking_water_time_cat returns expected column", {
   result <- add_drinking_water_time_cat(dummy_data)
   expect_true("wash_drinking_water_time_cat" %in% colnames(result))
+})
+
+
+test_that("add_drinking_water_time_cat errors on wrong sl_under_30_min values", {
+  expect_error(
+    add_drinking_water_time_cat(dummy_data, sl_under_30_min = "foo"),
+    regexp = '.*should be one of "5min_or_less", "5min_15min", "15min_30min".*'
+  )
+
+  expect_error(
+    add_drinking_water_time_cat(
+      dummy_data,
+      sl_under_30_min = c("5min_15min", "15min_30min")
+    ),
+    regexp = ".* must be of length 1"
+  )
 })
 
 test_that("add_drinking_water_quality_jmp_cat returns expected column", {


### PR DESCRIPTION
## Summary

- Update `add_drinking_water_time_cat()`'s `water_on_premises` default from `"water_on_premises"` to `c("water_in_dwelling", "water_in_plot")`, matching the current XLSForm choices
- Update `sl_under_30_min` default from `"under_30_min"` to `c("5min_or_less", "5min_15min", "15min_30min")`, matching the current XLSForm choices
- Add `match.arg()` validation for `sl_under_30_min` to enforce single-value input and provide a clear error on invalid values
- Update tests to align with new default values

Closes #717