### PR TITLE
refactor(wash): update add_sanitation_facility_cat unimproved defaults to match updated form

### DIFF
--- a/R/add_sanitation_facility_cat.R
+++ b/R/add_sanitation_facility_cat.R
@@ -30,11 +30,11 @@ add_sanitation_facility_cat <- function(
   ),
   unimproved = c(
     "flush_open_drain",
-    "flush_elsewhere",
     "pit_latrine_wo_slab",
     "bucket",
     "hanging_toilet",
-    "plastic_bag"
+    "twin_pit_latrine_wo_slab",
+    "other_container"
   ),
   none = "none",
   undefined = c("other", "dnk", "pnta")

--- a/man/add_sanitation_facility_cat.Rd
+++ b/man/add_sanitation_facility_cat.Rd
@@ -13,8 +13,8 @@ add_sanitation_facility_cat(
   improved = c("flush_piped_sewer", "flush_septic_tank", "flush_pit_latrine",
     "flush_dnk_where", "pit_latrine_slab", "twin_pit_latrine_slab",
     "ventilated_pit_latrine_slab", "container", "compost"),
-  unimproved = c("flush_open_drain", "flush_elsewhere", "pit_latrine_wo_slab", "bucket",
-    "hanging_toilet", "plastic_bag"),
+  unimproved = c("flush_open_drain", "pit_latrine_wo_slab", "bucket", "hanging_toilet",
+    "twin_pit_latrine_wo_slab", "other_container"),
   none = "none",
   undefined = c("other", "dnk", "pnta")
 )


### PR DESCRIPTION
## Summary

- Add `"twin_pit_latrine_wo_slab"` and `"other_container"` to `add_sanitation_facility_cat()`'s `unimproved` default list, matching the current XLSForm choices
- Remove `"flush_elsewhere"` and `"plastic_bag"` (not found in current XLSForm choices)

Closes #720