### PR TITLE
feat(msni): add sector_in_severe_need_n and sector_severe_needs_profile to add_msni

### DIFF
--- a/R/add_msni.R
+++ b/R/add_msni.R
@@ -24,14 +24,21 @@
 #' @param comp_prot_in_need Column name for protection in need.
 #' @param comp_health_in_need Column name for health in need.
 #' @param comp_edu_in_need Column name for education in need.
+#' @param comp_foodsec_in_severe_need Column name for food security in severe need.
+#' @param comp_snfi_in_severe_need Column name for SNFI in severe need.
+#' @param comp_wash_in_severe_need Column name for WASH in severe need.
+#' @param comp_prot_in_severe_need Column name for protection in severe need.
+#' @param comp_edu_in_severe_need Column name for education in severe need.
 #'
-#' @return A data frame with 5 new columns:
+#' @return A data frame with 7 new columns:
 #'
 #' * msni_score: The Multi-Sectoral Needs Index score.
 #' * msni_in_need: Binary indicator for households in need.
 #' * msni_in_severe_need: Binary indicator for households in severe need.
 #' * sector_in_need_n: Number of sectoral needs identified.
+#' * sector_in_severe_need_n: Number of sectoral severe needs identified.
 #' * sector_needs_profile: Profile of sectoral needs identified (NA if no sectoral need is identified).
+#' * sector_severe_needs_profile: Profile of sectoral severe needs identified (NA if no sectoral severe need is identified).
 #'
 #' @export
 add_msni <- function(
@@ -47,7 +54,12 @@ add_msni <- function(
   comp_wash_in_need = "comp_wash_in_need",
   comp_prot_in_need = "comp_prot_in_need",
   comp_health_in_need = "comp_health_in_need",
-  comp_edu_in_need = "comp_edu_in_need"
+  comp_edu_in_need = "comp_edu_in_need",
+  comp_foodsec_in_severe_need = "comp_foodsec_in_severe_need",
+  comp_snfi_in_severe_need = "comp_snfi_in_severe_need",
+  comp_wash_in_severe_need = "comp_wash_in_severe_need",
+  comp_prot_in_severe_need = "comp_prot_in_severe_need",
+  comp_edu_in_severe_need = "comp_edu_in_severe_need"
 ) {
   #------ Checks
 
@@ -74,6 +86,13 @@ add_msni <- function(
     "WASH",
     "Protection",
     "Health",
+    "Education"
+  )
+  comp_names_severe <- c(
+    "Food security",
+    "SNFI",
+    "WASH",
+    "Protection",
     "Education"
   )
 
@@ -114,6 +133,32 @@ add_msni <- function(
     rlang::warn(paste(
       "The following variables are not in the data frame and the number of sectoral needs and the needs profile calculation will be run without them:",
       paste(comp_in_need_nin, collapse = ", ")
+    ))
+  }
+
+  # Check that the dummy variables for in severe need are in df
+  comp_in_severe_need <- c(
+    comp_foodsec_in_severe_need,
+    comp_snfi_in_severe_need,
+    comp_wash_in_severe_need,
+    comp_prot_in_severe_need,
+    comp_edu_in_severe_need
+  )
+  comp_in_severe_need_lgl <- comp_in_severe_need %in% colnames(df)
+  comp_in_severe_need_nin <- comp_in_severe_need[!comp_in_severe_need_lgl]
+  comp_in_severe_need <- comp_in_severe_need[comp_in_severe_need_lgl]
+  comp_names_severe <- comp_names_severe[comp_in_severe_need_lgl]
+  # all missing
+  if (!all(comp_in_severe_need_lgl)) {
+    rlang::abort(paste(
+      "There are none of the sectoral composites 'in severe need' variables. Are you sure you specified the names correctly or you have run the necessary functions to add them?"
+    ))
+  }
+  # Some missing
+  if (any(!comp_in_severe_need_lgl)) {
+    rlang::warn(paste(
+      "The following variables are not in the data frame and the number of sectoral severe needs calculation will be run without them:",
+      paste(comp_in_severe_need_nin, collapse = ", ")
     ))
   }
 
@@ -164,6 +209,27 @@ add_msni <- function(
     )
   )
 
+  #------ Add number of sectoral severe needs
+
+  # Sum vars across composites in severe need
+  df <- sum_vars(
+    df,
+    comp_in_severe_need,
+    "sector_in_severe_need_n",
+    na_rm = TRUE,
+    imputation = "none"
+  )
+
+  # If the sum is zero, NA the result
+  df <- dplyr::mutate(
+    df,
+    sector_in_severe_need_n = ifelse(
+      !!rlang::sym("sector_in_severe_need_n") == 0,
+      NA,
+      !!rlang::sym("sector_in_severe_need_n")
+    )
+  )
+
   #------ Add needs profiles
 
   df_comp_in_need <- dplyr::select(df, dplyr::all_of(comp_in_need))
@@ -184,6 +250,32 @@ add_msni <- function(
       !!rlang::sym("sector_needs_profile") == "",
       NA,
       !!rlang::sym("sector_needs_profile")
+    )
+  )
+
+  #------ Add severe needs profile
+
+  df_comp_in_severe_need <- dplyr::select(
+    df,
+    dplyr::all_of(comp_in_severe_need)
+  )
+
+  df$sector_severe_needs_profile <- purrr::pmap_chr(
+    df_comp_in_severe_need,
+    function(...) {
+      values <- c(...)
+      labels <- comp_names_severe[values == 1 & !is.na(values)]
+      paste(labels, collapse = " - ")
+    }
+  )
+
+  # NA if empty character string
+  df <- dplyr::mutate(
+    df,
+    sector_severe_needs_profile = ifelse(
+      !!rlang::sym("sector_severe_needs_profile") == "",
+      NA,
+      !!rlang::sym("sector_severe_needs_profile")
     )
   )
 

--- a/R/add_msni.R
+++ b/R/add_msni.R
@@ -101,13 +101,13 @@ add_msni <- function(
   comp_scores_nin <- comp_scores[!comp_scores_lgl]
   comp_scores <- comp_scores[comp_scores_lgl]
   # all missing
-  if (!all(comp_scores_lgl)) {
+  if (!any(comp_scores_lgl)) {
     rlang::abort(paste(
       "There are none of the sectoral composites variables. Are you sure you specified the names correctly or you have run the necessary functions to add them?"
     ))
   }
   # Some missing
-  if (any(!comp_scores_lgl)) {
+  if (!all(comp_scores_lgl)) {
     rlang::warn(paste(
       "The following variables are not in the data frame and the MSNI calculation will be run without them:",
       paste(comp_scores_nin, collapse = ", ")
@@ -123,13 +123,13 @@ add_msni <- function(
   comp_in_need <- comp_in_need[comp_in_need_lgl]
   comp_names <- comp_names[comp_in_need_lgl]
   # all missing
-  if (!all(comp_in_need_lgl)) {
+  if (!any(comp_in_need_lgl)) {
     rlang::abort(paste(
       "There are none of the sectoral composites 'in need' variables. Are you sure you specified the names correctly or you have run the necessary functions to add them?"
     ))
   }
   # Some missing
-  if (any(!comp_in_need_lgl)) {
+  if (!all(comp_in_need_lgl)) {
     rlang::warn(paste(
       "The following variables are not in the data frame and the number of sectoral needs and the needs profile calculation will be run without them:",
       paste(comp_in_need_nin, collapse = ", ")
@@ -149,13 +149,13 @@ add_msni <- function(
   comp_in_severe_need <- comp_in_severe_need[comp_in_severe_need_lgl]
   comp_names_severe <- comp_names_severe[comp_in_severe_need_lgl]
   # all missing
-  if (!all(comp_in_severe_need_lgl)) {
+  if (!any(comp_in_severe_need_lgl)) {
     rlang::abort(paste(
       "There are none of the sectoral composites 'in severe need' variables. Are you sure you specified the names correctly or you have run the necessary functions to add them?"
     ))
   }
   # Some missing
-  if (any(!comp_in_severe_need_lgl)) {
+  if (!all(comp_in_severe_need_lgl)) {
     rlang::warn(paste(
       "The following variables are not in the data frame and the number of sectoral severe needs calculation will be run without them:",
       paste(comp_in_severe_need_nin, collapse = ", ")

--- a/man/add_msni.Rd
+++ b/man/add_msni.Rd
@@ -17,7 +17,12 @@ add_msni(
   comp_wash_in_need = "comp_wash_in_need",
   comp_prot_in_need = "comp_prot_in_need",
   comp_health_in_need = "comp_health_in_need",
-  comp_edu_in_need = "comp_edu_in_need"
+  comp_edu_in_need = "comp_edu_in_need",
+  comp_foodsec_in_severe_need = "comp_foodsec_in_severe_need",
+  comp_snfi_in_severe_need = "comp_snfi_in_severe_need",
+  comp_wash_in_severe_need = "comp_wash_in_severe_need",
+  comp_prot_in_severe_need = "comp_prot_in_severe_need",
+  comp_edu_in_severe_need = "comp_edu_in_severe_need"
 )
 }
 \arguments{
@@ -46,15 +51,27 @@ add_msni(
 \item{comp_health_in_need}{Column name for health in need.}
 
 \item{comp_edu_in_need}{Column name for education in need.}
+
+\item{comp_foodsec_in_severe_need}{Column name for food security in severe need.}
+
+\item{comp_snfi_in_severe_need}{Column name for SNFI in severe need.}
+
+\item{comp_wash_in_severe_need}{Column name for WASH in severe need.}
+
+\item{comp_prot_in_severe_need}{Column name for protection in severe need.}
+
+\item{comp_edu_in_severe_need}{Column name for education in severe need.}
 }
 \value{
-A data frame with 5 new columns:
+A data frame with 7 new columns:
 \itemize{
 \item msni_score: The Multi-Sectoral Needs Index score.
 \item msni_in_need: Binary indicator for households in need.
 \item msni_in_severe_need: Binary indicator for households in severe need.
 \item sector_in_need_n: Number of sectoral needs identified.
+\item sector_in_severe_need_n: Number of sectoral severe needs identified.
 \item sector_needs_profile: Profile of sectoral needs identified (NA if no sectoral need is identified).
+\item sector_severe_needs_profile: Profile of sectoral severe needs identified (NA if no sectoral severe need is identified).
 }
 }
 \description{

--- a/tests/testthat/test-add_msni.R
+++ b/tests/testthat/test-add_msni.R
@@ -11,7 +11,12 @@ test_that("add_msni works with default parameters", {
     comp_wash_in_need = c(0, 0, 0, 0, 0),
     comp_prot_in_need = c(1, 1, 1, 1, 1),
     comp_health_in_need = c(1, 1, 1, 1, 1),
-    comp_edu_in_need = c(1, 1, 1, 1, 1)
+    comp_edu_in_need = c(1, 1, 1, 1, 1),
+    comp_foodsec_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_snfi_in_severe_need = c(1, 0, 0, 0, 0),
+    comp_wash_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_edu_in_severe_need = c(1, 1, 1, 1, 1)
   )
 
   result <- humind:::add_msni(df)
@@ -35,6 +40,11 @@ test_that("add_msni works with default parameters", {
         comp_prot_in_need +
         comp_health_in_need +
         comp_edu_in_need,
+      sector_in_severe_need_n = comp_foodsec_in_severe_need +
+        comp_snfi_in_severe_need +
+        comp_wash_in_severe_need +
+        comp_prot_in_severe_need +
+        comp_edu_in_severe_need,
       sector_needs_profile = purrr::pmap_chr(
         list(
           comp_foodsec_in_need,
@@ -66,6 +76,34 @@ test_that("add_msni works with default parameters", {
           }
           paste(labels, collapse = " - ")
         }
+      ),
+      sector_severe_needs_profile = purrr::pmap_chr(
+        list(
+          comp_foodsec_in_severe_need,
+          comp_snfi_in_severe_need,
+          comp_wash_in_severe_need,
+          comp_prot_in_severe_need,
+          comp_edu_in_severe_need
+        ),
+        function(foodsec, snfi, wash, prot, edu) {
+          labels <- c()
+          if (foodsec == 1) {
+            labels <- c(labels, "Food security")
+          }
+          if (snfi == 1) {
+            labels <- c(labels, "SNFI")
+          }
+          if (wash == 1) {
+            labels <- c(labels, "WASH")
+          }
+          if (prot == 1) {
+            labels <- c(labels, "Protection")
+          }
+          if (edu == 1) {
+            labels <- c(labels, "Education")
+          }
+          paste(labels, collapse = " - ")
+        }
       )
     )
 
@@ -86,7 +124,12 @@ test_that("add_msni handles all possible values", {
     comp_wash_in_need = c(0, 0, 1, 1, 1),
     comp_prot_in_need = c(0, 0, 1, 1, 1),
     comp_health_in_need = c(0, 0, 1, 1, 1),
-    comp_edu_in_need = c(0, 0, 1, 1, 1)
+    comp_edu_in_need = c(0, 0, 1, 1, 1),
+    comp_foodsec_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_snfi_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_wash_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_prot_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_edu_in_severe_need = c(0, 0, 0, 1, 1)
   )
 
   result <- humind:::add_msni(df)
@@ -97,6 +140,7 @@ test_that("add_msni handles all possible values", {
       msni_in_need = ifelse(msni_score >= 3, 1, 0),
       msni_in_severe_need = ifelse(msni_score >= 4, 1, 0),
       sector_in_need_n = c(NA, NA, 6, 6, 6),
+      sector_in_severe_need_n = c(NA, NA, NA, 5, 5),
       sector_needs_profile = purrr::pmap_chr(
         list(
           comp_foodsec_in_need,
@@ -122,6 +166,35 @@ test_that("add_msni handles all possible values", {
           }
           if (health == 1) {
             labels <- c(labels, "Health")
+          }
+          if (edu == 1) {
+            labels <- c(labels, "Education")
+          }
+          p <- paste(labels, collapse = " - ")
+          p <- ifelse(p == "", NA, p)
+        }
+      ),
+      sector_severe_needs_profile = purrr::pmap_chr(
+        list(
+          comp_foodsec_in_severe_need,
+          comp_snfi_in_severe_need,
+          comp_wash_in_severe_need,
+          comp_prot_in_severe_need,
+          comp_edu_in_severe_need
+        ),
+        function(foodsec, snfi, wash, prot, edu) {
+          labels <- c()
+          if (foodsec == 1) {
+            labels <- c(labels, "Food security")
+          }
+          if (snfi == 1) {
+            labels <- c(labels, "SNFI")
+          }
+          if (wash == 1) {
+            labels <- c(labels, "WASH")
+          }
+          if (prot == 1) {
+            labels <- c(labels, "Protection")
           }
           if (edu == 1) {
             labels <- c(labels, "Education")

--- a/tests/testthat/test-add_msni.R
+++ b/tests/testthat/test-add_msni.R
@@ -217,7 +217,167 @@ test_that("add_msni handles missing columns", {
     comp_snfi_score = c(5, 4, 3, 2, 1)
   )
 
-  expect_error(humind:::add_msni(df), class = "error")
+  expect_error(suppressWarnings(humind:::add_msni(df)), class = "error")
+})
+
+test_that("add_msni warns (not aborts) when some score columns are missing", {
+  df <- data.frame(
+    comp_foodsec_score = c(1, 2, 3, 4, 5),
+    comp_snfi_score = c(5, 4, 3, 2, 1),
+    comp_wash_score = c(2, 2, 2, 2, 2),
+    comp_prot_score = c(3, 3, 3, 3, 3),
+    comp_health_score = c(4, 4, 4, 4, 4),
+    comp_foodsec_in_need = c(0, 0, 1, 1, 1),
+    comp_snfi_in_need = c(1, 1, 1, 0, 0),
+    comp_wash_in_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_need = c(1, 1, 1, 1, 1),
+    comp_health_in_need = c(1, 1, 1, 1, 1),
+    comp_edu_in_need = c(1, 1, 1, 1, 1),
+    comp_foodsec_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_snfi_in_severe_need = c(1, 0, 0, 0, 0),
+    comp_wash_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_edu_in_severe_need = c(1, 1, 1, 1, 1)
+  )
+
+  expect_warning(
+    result <- humind:::add_msni(df),
+    "comp_edu_score"
+  )
+
+  expect_equal(
+    result$msni_score,
+    pmax(
+      df$comp_foodsec_score,
+      df$comp_snfi_score,
+      df$comp_wash_score,
+      df$comp_prot_score,
+      df$comp_health_score,
+      na.rm = TRUE
+    )
+  )
+})
+
+test_that("add_msni aborts when all score columns are missing", {
+  df <- data.frame(
+    comp_foodsec_in_need = c(0, 0, 1, 1, 1),
+    comp_snfi_in_need = c(1, 1, 1, 0, 0)
+  )
+
+  expect_error(
+    humind:::add_msni(df),
+    "none of the sectoral composites variables"
+  )
+})
+
+test_that("add_msni warns (not aborts) when some in_need columns are missing", {
+  df <- data.frame(
+    comp_foodsec_score = c(1, 2, 3, 4, 5),
+    comp_snfi_score = c(5, 4, 3, 2, 1),
+    comp_wash_score = c(2, 2, 2, 2, 2),
+    comp_prot_score = c(3, 3, 3, 3, 3),
+    comp_health_score = c(4, 4, 4, 4, 4),
+    comp_edu_score = c(5, 5, 5, 5, 5),
+    comp_foodsec_in_need = c(0, 0, 1, 1, 1),
+    comp_snfi_in_need = c(1, 1, 1, 0, 0),
+    comp_wash_in_need = c(0, 0, 0, 0, 0),
+    comp_health_in_need = c(1, 1, 1, 1, 1),
+    comp_edu_in_need = c(1, 1, 1, 1, 1),
+    comp_foodsec_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_snfi_in_severe_need = c(1, 0, 0, 0, 0),
+    comp_wash_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_edu_in_severe_need = c(1, 1, 1, 1, 1)
+  )
+
+  expect_warning(
+    result <- humind:::add_msni(df),
+    "comp_prot_in_need"
+  )
+
+  expect_equal(
+    result$sector_in_need_n,
+    df$comp_foodsec_in_need +
+      df$comp_snfi_in_need +
+      df$comp_wash_in_need +
+      df$comp_health_in_need +
+      df$comp_edu_in_need
+  )
+})
+
+test_that("add_msni aborts when all in_need columns are missing", {
+  df <- data.frame(
+    comp_foodsec_score = c(1, 2, 3, 4, 5),
+    comp_snfi_score = c(5, 4, 3, 2, 1),
+    comp_wash_score = c(2, 2, 2, 2, 2),
+    comp_prot_score = c(3, 3, 3, 3, 3),
+    comp_health_score = c(4, 4, 4, 4, 4),
+    comp_edu_score = c(5, 5, 5, 5, 5)
+  )
+
+  expect_error(
+    humind:::add_msni(df),
+    "none of the sectoral composites 'in need' variables"
+  )
+})
+
+test_that("add_msni warns (not aborts) when some in_severe_need columns are missing", {
+  df <- data.frame(
+    comp_foodsec_score = c(1, 2, 3, 4, 5),
+    comp_snfi_score = c(5, 4, 3, 2, 1),
+    comp_wash_score = c(2, 2, 2, 2, 2),
+    comp_prot_score = c(3, 3, 3, 3, 3),
+    comp_health_score = c(4, 4, 4, 4, 4),
+    comp_edu_score = c(5, 5, 5, 5, 5),
+    comp_foodsec_in_need = c(0, 0, 1, 1, 1),
+    comp_snfi_in_need = c(1, 1, 1, 0, 0),
+    comp_wash_in_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_need = c(1, 1, 1, 1, 1),
+    comp_health_in_need = c(1, 1, 1, 1, 1),
+    comp_edu_in_need = c(1, 1, 1, 1, 1),
+    comp_foodsec_in_severe_need = c(0, 0, 0, 1, 1),
+    comp_snfi_in_severe_need = c(1, 0, 0, 0, 0),
+    comp_wash_in_severe_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_severe_need = c(0, 0, 0, 0, 0)
+  )
+
+  expect_warning(
+    result <- humind:::add_msni(df),
+    "comp_edu_in_severe_need"
+  )
+
+  expect_equal(
+    result$sector_in_severe_need_n,
+    dplyr::na_if(
+      df$comp_foodsec_in_severe_need +
+        df$comp_snfi_in_severe_need +
+        df$comp_wash_in_severe_need +
+        df$comp_prot_in_severe_need,
+      0
+    )
+  )
+})
+
+test_that("add_msni aborts when all in_severe_need columns are missing", {
+  df <- data.frame(
+    comp_foodsec_score = c(1, 2, 3, 4, 5),
+    comp_snfi_score = c(5, 4, 3, 2, 1),
+    comp_wash_score = c(2, 2, 2, 2, 2),
+    comp_prot_score = c(3, 3, 3, 3, 3),
+    comp_health_score = c(4, 4, 4, 4, 4),
+    comp_edu_score = c(5, 5, 5, 5, 5),
+    comp_foodsec_in_need = c(0, 0, 1, 1, 1),
+    comp_snfi_in_need = c(1, 1, 1, 0, 0),
+    comp_wash_in_need = c(0, 0, 0, 0, 0),
+    comp_prot_in_need = c(1, 1, 1, 1, 1),
+    comp_health_in_need = c(1, 1, 1, 1, 1),
+    comp_edu_in_need = c(1, 1, 1, 1, 1)
+  )
+
+  expect_error(
+    humind:::add_msni(df),
+    "none of the sectoral composites 'in severe need' variables"
+  )
 })
 
 test_that("add_msni handles out-of-range values", {


### PR DESCRIPTION
## Summary

- Add `sector_in_severe_need_n` to `add_msni()`, computed the same way as `sector_in_need_n` but from the sectoral `comp_*_in_severe_need` flags (Food security, SNFI, WASH, Protection, Education; Health is excluded since `comp_health_score` caps at 3 and can never cross the severe threshold)
- Add `sector_severe_needs_profile`, mirroring `sector_needs_profile` but built from the severe-need flags
- Fix the "all missing" validation checks (scores, in_need, in_severe_need): they used `!all(x)` to guard the abort, which triggers as soon as a *single* column is missing rather than when *all* are missing, making the "some missing → warn and continue" branch unreachable. Corrected to `!any(x)` for the abort and `!all(x)` for the warn
- Update tests and regenerate `man/add_msni.Rd`

Closes #741