### PR TITLE
fix(add_fcs): update normal cutoff threshold from < 21.5 to <= 21

### DIFF
--- a/R/add_fcs.R
+++ b/R/add_fcs.R
@@ -247,7 +247,7 @@ add_fcs <- function(
     .dataset <- .dataset |>
       dplyr::mutate(
         fsl_fcs_cat = dplyr::case_when(
-          fsl_fcs_score < 21.5 ~ "Poor",
+          fsl_fcs_score <= 21 ~ "Poor",
           fsl_fcs_score <= 35 ~ "Borderline",
           fsl_fcs_score > 35 ~ "Acceptable",
           TRUE ~ NA


### PR DESCRIPTION
## Summary

Update the `"Poor"` category threshold in `add_fcs()` under the `"normal"` cutoff from `< 21.5` to `<= 21`, per Olivia's review of FCS thresholds.

Closes #750