### PR TITLE
fix(add_hhs): recode genuinely missing _freq values to NA, not 0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,25 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9021
+    rev: v0.4.3.9030
     hooks:
     -   id: roxygenize
+        # roxygen requires loading pkg -> add dependencies from DESCRIPTION
         additional_dependencies:
         - roxygen2@8.0.0
-        - readxl
+        - dplyr@1.2.0
+        - glue
+        - purrr
         - rlang@1.2.0
-        - tibble
+        - stats
         - tidyr
-        - Hmisc
         - impact-initiatives/impactR.utils
+        - Hmisc
+        - stringr
+        - cli
+        - checkmate
+        - readxl
+        - tibble
     # codemeta must be above use-tidy-description when both are used
     # -   id: codemeta-description-updated
     -   id: use-tidy-description
@@ -81,7 +89,7 @@ repos:
     -   id: conventional-pre-commit
         stages: [commit-msg]
 -   repo: https://github.com/posit-dev/air-pre-commit
-    rev: 0.9.0
+    rev: 0.11.0
     hooks:
     -   id: air-format
 -   repo: local

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,10 +31,11 @@ URL: https://impact-initiatives-hppu.github.io/humind,
 BugReports: https://github.com/impact-initiatives-hppu/humind/issues
 Remotes: 
     impact-initiatives/impactR.utils
-Suggests: 
+Suggests:
     rmarkdown,
     roxygen2,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    tibble
 Config/Needs/website: rmarkdown
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/R/add_hhs.R
+++ b/R/add_hhs.R
@@ -178,21 +178,32 @@ add_hhs <- function(
   }
 
   .dataset_with_calculation <- .dataset |>
+    dplyr::mutate(
+      "{fsl_hhs_nofoodhh_freq}" := dplyr::case_when(
+        .data[[fsl_hhs_nofoodhh_freq]] %in%
+          c(rarely_answer, sometimes_answer) ~ 1,
+        .data[[fsl_hhs_nofoodhh_freq]] == often_answer ~ 2,
+        .data[[fsl_hhs_nofoodhh]] == no_answer ~ 0,
+        TRUE ~ NA_real_
+      ),
+      "{fsl_hhs_sleephungry_freq}" := dplyr::case_when(
+        .data[[fsl_hhs_sleephungry_freq]] %in%
+          c(rarely_answer, sometimes_answer) ~ 1,
+        .data[[fsl_hhs_sleephungry_freq]] == often_answer ~ 2,
+        .data[[fsl_hhs_sleephungry]] == no_answer ~ 0,
+        TRUE ~ NA_real_
+      ),
+      "{fsl_hhs_alldaynight_freq}" := dplyr::case_when(
+        .data[[fsl_hhs_alldaynight_freq]] %in%
+          c(rarely_answer, sometimes_answer) ~ 1,
+        .data[[fsl_hhs_alldaynight_freq]] == often_answer ~ 2,
+        .data[[fsl_hhs_alldaynight]] == no_answer ~ 0,
+        TRUE ~ NA_real_
+      )
+    ) |>
     dplyr::mutate_at(
       c(fsl_hhs_nofoodhh, fsl_hhs_sleephungry, fsl_hhs_alldaynight),
       ~ dplyr::case_when(.x == yes_answer ~ 1, .x == no_answer ~ 0)
-    ) |>
-    dplyr::mutate_at(
-      c(
-        fsl_hhs_nofoodhh_freq,
-        fsl_hhs_sleephungry_freq,
-        fsl_hhs_alldaynight_freq
-      ),
-      ~ dplyr::case_when(
-        .x %in% c(rarely_answer, sometimes_answer) ~ 1,
-        .x == often_answer ~ 2,
-        TRUE ~ 0
-      )
     ) |>
     dplyr::rowwise() |>
     dplyr::mutate(

--- a/tests/testthat/helper-add_hhs.R
+++ b/tests/testthat/helper-add_hhs.R
@@ -1,0 +1,30 @@
+generate_hhs_df <- function() {
+  yn_codes <- c("yes", "no", NA_character_)
+  freq_codes <- c("rarely", "sometimes", "often", NA_character_)
+
+  # Valid yn x freq combinations: if yn == "yes", freq must have a value.
+  # Otherwise (yn == "no" or NA), freq must be NA.
+  pair <- tidyr::expand_grid(yn = yn_codes, freq = freq_codes) |>
+    dplyr::filter(
+      (!is.na(yn) & yn == "yes" & !is.na(freq)) |
+        ((is.na(yn) | yn == "no") & is.na(freq))
+    )
+
+  tidyr::expand_grid(
+    nofoodhh = pair,
+    sleephungry = pair,
+    alldaynight = pair
+  ) |>
+    tidyr::unpack(
+      c(nofoodhh, sleephungry, alldaynight),
+      names_sep = "_"
+    ) |>
+    dplyr::rename(
+      fsl_hhs_nofoodhh = nofoodhh_yn,
+      fsl_hhs_nofoodhh_freq = nofoodhh_freq,
+      fsl_hhs_sleephungry = sleephungry_yn,
+      fsl_hhs_sleephungry_freq = sleephungry_freq,
+      fsl_hhs_alldaynight = alldaynight_yn,
+      fsl_hhs_alldaynight_freq = alldaynight_freq
+    )
+}

--- a/tests/testthat/test-add_hhs.R
+++ b/tests/testthat/test-add_hhs.R
@@ -1,0 +1,139 @@
+# The recoding rule is the same regardless of which of the 3 pairs it's
+# applied to (R/add_hhs.R doesn't special-case any of them), so this table
+# is the single source of truth for it - written once, checked once per
+# pair below.
+
+hhs_pair_cases <- tibble::tribble(
+  ~case                                               , ~yn           , ~freq         , ~expected_yn_recoded , ~expected_freq_recoded , ~expected_comp ,
+  "answered rarely"                                   , "yes"         , "rarely"      ,                    1 ,                      1 ,              1 ,
+  "answered sometimes"                                , "yes"         , "sometimes"   ,                    1 ,                      1 ,              1 ,
+  "answered often"                                    , "yes"         , "often"       ,                    1 ,                      2 ,              2 ,
+  "\"no\": freq not relevant, legitimate skip"        , "no"          , NA_character_ ,                    0 ,                      0 ,              0 ,
+  "yn missing: whole module skipped, legitimate skip" , NA_character_ , NA_character_ , NA_real_             , NA_real_               , NA_real_       ,
+  "\"yes\" but freq missing: issue #753"              , "yes"         , NA_character_ ,                    1 , NA_real_               , NA_real_       ,
+)
+
+# The other two pairs are held "no" + NA (comp = 0) so the pair under test
+# can be checked in isolation from the other two.
+neutral_hhs_row <- list(
+  fsl_hhs_nofoodhh = "no",
+  fsl_hhs_nofoodhh_freq = NA_character_,
+  fsl_hhs_sleephungry = "no",
+  fsl_hhs_sleephungry_freq = NA_character_,
+  fsl_hhs_alldaynight = "no",
+  fsl_hhs_alldaynight_freq = NA_character_
+)
+
+# Applies hhs_pair_cases to one specific yn/_freq pair (identified by its
+# column names) and checks its recoded columns and component score.
+expect_hhs_pair_matches_cases <- function(yn_col, freq_col, comp_col) {
+  other_cols <- neutral_hhs_row[
+    !names(neutral_hhs_row) %in% c(yn_col, freq_col)
+  ]
+  df <- dplyr::tibble(
+    !!yn_col := hhs_pair_cases$yn,
+    !!freq_col := hhs_pair_cases$freq
+  )
+  for (col in names(other_cols)) {
+    df[[col]] <- other_cols[[col]]
+  }
+  result <- add_hhs(df)
+
+  expect_equal(
+    result[[paste0(yn_col, "_recoded")]],
+    hhs_pair_cases$expected_yn_recoded
+  )
+  expect_equal(
+    result[[paste0(freq_col, "_recoded")]],
+    hhs_pair_cases$expected_freq_recoded
+  )
+  expect_equal(result[[comp_col]], hhs_pair_cases$expected_comp)
+}
+
+test_that("fsl_hhs_nofoodhh / fsl_hhs_nofoodhh_freq recode as expected for every case", {
+  expect_hhs_pair_matches_cases(
+    "fsl_hhs_nofoodhh",
+    "fsl_hhs_nofoodhh_freq",
+    "fsl_hhs_comp1"
+  )
+})
+
+test_that("fsl_hhs_sleephungry / fsl_hhs_sleephungry_freq recode as expected for every case", {
+  expect_hhs_pair_matches_cases(
+    "fsl_hhs_sleephungry",
+    "fsl_hhs_sleephungry_freq",
+    "fsl_hhs_comp2"
+  )
+})
+
+test_that("fsl_hhs_alldaynight / fsl_hhs_alldaynight_freq recode as expected for every case", {
+  expect_hhs_pair_matches_cases(
+    "fsl_hhs_alldaynight",
+    "fsl_hhs_alldaynight_freq",
+    "fsl_hhs_comp3"
+  )
+})
+
+
+score_cases <- tibble::tribble(
+  ~fsl_hhs_nofoodhh , ~fsl_hhs_nofoodhh_freq , ~fsl_hhs_sleephungry , ~fsl_hhs_sleephungry_freq , ~fsl_hhs_alldaynight , ~fsl_hhs_alldaynight_freq , ~expected_score , ~expected_cat_ipc , ~expected_cat  ,
+  "no"              , NA_character_          , "no"                 , NA_character_             , "no"                 , NA_character_             ,               0 , "None"            , "Little to No" ,
+  "yes"             , "rarely"               , "no"                 , NA_character_             , "no"                 , NA_character_             ,               1 , "Little"          , "Little to No" ,
+  "yes"             , "often"                , "no"                 , NA_character_             , "no"                 , NA_character_             ,               2 , "Moderate"        , "Moderate"     ,
+  "yes"             , "often"                , "yes"                , "rarely"                  , "no"                 , NA_character_             ,               3 , "Moderate"        , "Moderate"     ,
+  "yes"             , "often"                , "yes"                , "often"                   , "no"                 , NA_character_             ,               4 , "Severe"          , "Severe"       ,
+  "yes"             , "often"                , "yes"                , "often"                   , "yes"                , "rarely"                  ,               5 , "Very Severe"     , "Severe"       ,
+  "yes"             , "often"                , "yes"                , "often"                   , "yes"                , "often"                   ,               6 , "Very Severe"     , "Severe"       ,
+)
+
+test_that("fsl_hhs_score and categories are correct across the full 0-6 range", {
+  df <- dplyr::select(score_cases, dplyr::starts_with("fsl_hhs"))
+  result <- add_hhs(df)
+
+  expect_equal(result$fsl_hhs_score, score_cases$expected_score)
+  expect_equal(result$fsl_hhs_cat_ipc, score_cases$expected_cat_ipc)
+  expect_equal(result$fsl_hhs_cat, score_cases$expected_cat)
+})
+
+# Property based tests
+
+exhaustive_hhs_df <- generate_hhs_df()
+exhaustive_hhs_result <- add_hhs(exhaustive_hhs_df)
+
+test_that("regression: fsl_hhs_score is NA iff at least one component is NA", {
+  comp_cols <- c("fsl_hhs_comp1", "fsl_hhs_comp2", "fsl_hhs_comp3")
+  any_na_comp <- apply(exhaustive_hhs_result[comp_cols], 1, function(x) {
+    any(is.na(x))
+  })
+  expect_identical(is.na(exhaustive_hhs_result$fsl_hhs_score), any_na_comp)
+})
+
+test_that("regression: fsl_hhs_score is in 0-6 for all non-NA rows", {
+  score <- exhaustive_hhs_result$fsl_hhs_score
+  expect_true(all(score[!is.na(score)] %in% 0:6))
+})
+
+test_that("regression: fsl_hhs_cat and fsl_hhs_cat_ipc are NA iff fsl_hhs_score is NA", {
+  score <- exhaustive_hhs_result$fsl_hhs_score
+  expect_identical(is.na(exhaustive_hhs_result$fsl_hhs_cat), is.na(score))
+  expect_identical(is.na(exhaustive_hhs_result$fsl_hhs_cat_ipc), is.na(score))
+})
+
+test_that("fsl_hhs_score is NA (not deflated to 0) when a freq answer is genuinely missing", {
+  # This case should not happen on a well coded / cleaned data set
+
+  df <- dplyr::tibble(
+    fsl_hhs_nofoodhh = "yes",
+    fsl_hhs_nofoodhh_freq = NA_character_,
+    fsl_hhs_sleephungry = "no",
+    fsl_hhs_sleephungry_freq = NA_character_,
+    fsl_hhs_alldaynight = "no",
+    fsl_hhs_alldaynight_freq = NA_character_
+  )
+  result <- add_hhs(df)
+
+  expect_true(is.na(result$fsl_hhs_comp1))
+  expect_true(is.na(result$fsl_hhs_score))
+  expect_true(is.na(result$fsl_hhs_cat))
+  expect_true(is.na(result$fsl_hhs_cat_ipc))
+})


### PR DESCRIPTION
## Summary
`add_hhs()` recoded a missing `_freq` answer (e.g. `fsl_hhs_nofoodhh_freq`) to `0` regardless of the paired yes/no answer. This silently conflated two different situations:
- a legitimate skip (`fsl_hhs_nofoodhh == "no"`, so the freq question was never shown)
- genuinely missing data (`fsl_hhs_nofoodhh == "yes"`, but the freq follow-up wasn't captured)

Both produced `fsl_hhs_comp = 0`, deflating `fsl_hhs_score` for incomplete records instead of surfacing them as `NA`.

## Fix
Each `_freq` column is now recoded against its paired yes/no column: `0` only when the pair was legitimately skipped (`yn == "no"`), `NA` otherwise. NA propagates correctly through `fsl_hhs_comp*`, `fsl_hhs_score` (`rowSums(na.rm = FALSE)`), `fsl_hhs_cat`, and `fsl_hhs_cat_ipc`.

Per `form.xlsx`, `yn == "yes"` with `freq == NA` isn't a reachable state through a compliant submission (freq is `relevant` + `required` whenever `yn == "yes"`) — but it can still appear in real datasets (partial syncs, edits outside the app, older form versions), which is what this defends against.

## Tests
- `tests/testthat/helper-add_hhs.R`: exhaustive grid over every reachable yn/freq state per pair (125 rows)
- `tests/testthat/test-add_hhs.R`:
  - per-pair recode truth table (all reachable states + the issue's missing-freq case)
  - score/category truth table across the full 0-6 range
  - regression checks over the exhaustive grid (NA propagation, score range, category consistency)
  - direct reproduction of the issue's reported example

Full suite passes locally (all test files, no failures/warnings).

Fixes #753